### PR TITLE
[feat] #18 팀원모집 게시물 댓글, 대댓글 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 .DS_Store
-/src/main/resources/application-local.yaml
 
 ### STS ###
 .apt_generated

--- a/src/main/java/org/example/weneedbe/domain/article/domain/Article.java
+++ b/src/main/java/org/example/weneedbe/domain/article/domain/Article.java
@@ -82,7 +82,6 @@ public class Article extends BaseTimeEntity {
     private List<File> files;
 
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
-    @Where(clause = "parent_id is null")
     private List<Comment> commentList = new ArrayList<>();
 
     public static Article of(String thumbnail, List<String> images, List<String> files,

--- a/src/main/java/org/example/weneedbe/domain/comment/api/CommentController.java
+++ b/src/main/java/org/example/weneedbe/domain/comment/api/CommentController.java
@@ -1,0 +1,35 @@
+package org.example.weneedbe.domain.comment.api;
+
+import lombok.RequiredArgsConstructor;
+import org.example.weneedbe.domain.comment.application.CommentService;
+import org.example.weneedbe.domain.comment.dto.request.AddCommentRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/recruit")
+@RequiredArgsConstructor
+public class CommentController {
+
+  private final CommentService commentService;
+
+  @PostMapping("/{articleId}")
+  public ResponseEntity<Void> createComment(@PathVariable Long articleId,
+      @RequestBody AddCommentRequest request) {
+    commentService.createComment(articleId, request);
+    return ResponseEntity.status(HttpStatus.CREATED).build();
+  }
+
+  @DeleteMapping("/{articleId}/{commentId}")
+  public ResponseEntity<Void> deleteComment(@PathVariable Long articleId,
+      @PathVariable Long commentId) {
+    commentService.deleteComment(articleId, commentId);
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/org/example/weneedbe/domain/comment/api/CommentController.java
+++ b/src/main/java/org/example/weneedbe/domain/comment/api/CommentController.java
@@ -1,8 +1,14 @@
 package org.example.weneedbe.domain.comment.api;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.example.weneedbe.domain.comment.application.CommentService;
 import org.example.weneedbe.domain.comment.dto.request.AddCommentRequest;
+import org.example.weneedbe.global.error.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -19,6 +25,13 @@ public class CommentController {
 
   private final CommentService commentService;
 
+  @Operation(summary = "댓글 작성", description = "리크루팅 게시물에 댓글을 작성합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "201"),
+      @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
   @PostMapping("/{articleId}")
   public ResponseEntity<Void> createComment(@PathVariable Long articleId,
       @RequestBody AddCommentRequest request) {
@@ -26,6 +39,13 @@ public class CommentController {
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 
+  @Operation(summary = "댓글 삭제", description = "사용자가 댓글을 삭제합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200"),
+      @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
   @DeleteMapping("/{articleId}/{commentId}")
   public ResponseEntity<Void> deleteComment(@PathVariable Long articleId,
       @PathVariable Long commentId) {

--- a/src/main/java/org/example/weneedbe/domain/comment/application/CommentService.java
+++ b/src/main/java/org/example/weneedbe/domain/comment/application/CommentService.java
@@ -6,6 +6,7 @@ import org.example.weneedbe.domain.article.exception.ArticleNotFoundException;
 import org.example.weneedbe.domain.article.repository.ArticleRepository;
 import org.example.weneedbe.domain.comment.domain.Comment;
 import org.example.weneedbe.domain.comment.dto.request.AddCommentRequest;
+import org.example.weneedbe.domain.comment.exception.CommentNotFoundException;
 import org.example.weneedbe.domain.comment.repository.CommentRepository;
 import org.example.weneedbe.domain.user.domain.User;
 import org.example.weneedbe.domain.user.repository.UserRepository;
@@ -34,7 +35,7 @@ public class CommentService {
     /* 부모 댓글이 있는 경우 */
     if (request.getParentId() != 0) {
       Comment parentComment = commentRepository.findById(request.getParentId())
-          .orElseThrow();
+          .orElseThrow(CommentNotFoundException::new);
       parentComment.addChild(comment);
     } else {
       article.getCommentList().add(comment);
@@ -46,7 +47,8 @@ public class CommentService {
     Article article = articleRepository.findById(articleId)
         .orElseThrow(ArticleNotFoundException::new);
 
-    Comment comment = commentRepository.findById(commentId).orElseThrow();
+    Comment comment = commentRepository.findById(commentId)
+        .orElseThrow(CommentNotFoundException::new);
 
     /* 최상위 댓글일 경우 */
     if (comment.getParentId() == 0) {

--- a/src/main/java/org/example/weneedbe/domain/comment/application/CommentService.java
+++ b/src/main/java/org/example/weneedbe/domain/comment/application/CommentService.java
@@ -1,0 +1,60 @@
+package org.example.weneedbe.domain.comment.application;
+
+import lombok.RequiredArgsConstructor;
+import org.example.weneedbe.domain.article.domain.Article;
+import org.example.weneedbe.domain.article.exception.ArticleNotFoundException;
+import org.example.weneedbe.domain.article.repository.ArticleRepository;
+import org.example.weneedbe.domain.comment.domain.Comment;
+import org.example.weneedbe.domain.comment.dto.request.AddCommentRequest;
+import org.example.weneedbe.domain.comment.repository.CommentRepository;
+import org.example.weneedbe.domain.user.domain.User;
+import org.example.weneedbe.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+  private final ArticleRepository articleRepository;
+  private final CommentRepository commentRepository;
+  private final UserRepository userRepository;
+
+  @Transactional
+  public void createComment(Long articleId, AddCommentRequest request) {
+    Article article = articleRepository.findById(articleId).orElseThrow(
+        ArticleNotFoundException::new);
+
+    /* 토큰을 통한 user 객체를 불러옴 */
+    /* 아직 토큰이 없기 때문에 임시 객체를 사용 */
+    User mockUser = userRepository.findById(1L).orElseThrow();
+
+    Comment comment = Comment.of(request, article, mockUser);
+
+    /* 부모 댓글이 있는 경우 */
+    if (request.getParentId() != 0) {
+      Comment parentComment = commentRepository.findById(request.getParentId())
+          .orElseThrow();
+      parentComment.addChild(comment);
+    } else {
+      article.getCommentList().add(comment);
+      commentRepository.save(comment);
+    }
+  }
+
+  public void deleteComment(Long articleId, Long commentId) {
+    Article article = articleRepository.findById(articleId)
+        .orElseThrow(ArticleNotFoundException::new);
+
+    Comment comment = commentRepository.findById(commentId).orElseThrow();
+
+    /* 최상위 댓글일 경우 */
+    if (comment.getParentId() == 0) {
+      comment.deleteChild();
+    } else {
+      article.getCommentList().remove(comment);
+    }
+
+    commentRepository.delete(comment);
+  }
+}

--- a/src/main/java/org/example/weneedbe/domain/comment/domain/Comment.java
+++ b/src/main/java/org/example/weneedbe/domain/comment/domain/Comment.java
@@ -40,7 +40,7 @@ public class Comment {
     private String content;
 
     @Column(name = "parent_id")
-    private Long parentId;
+    private long parentId;
 
     @OneToMany(mappedBy = "parentId", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> children = new ArrayList<>();

--- a/src/main/java/org/example/weneedbe/domain/comment/domain/Comment.java
+++ b/src/main/java/org/example/weneedbe/domain/comment/domain/Comment.java
@@ -1,22 +1,26 @@
 package org.example.weneedbe.domain.comment.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
-import org.example.weneedbe.domain.article.domain.Article;
-import org.example.weneedbe.domain.user.domain.User;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.weneedbe.domain.article.domain.Article;
+import org.example.weneedbe.domain.comment.dto.request.AddCommentRequest;
+import org.example.weneedbe.domain.user.domain.User;
 
 @Entity
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @Table(name="comment")
 public class Comment {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "comment_id")
@@ -24,23 +28,40 @@ public class Comment {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
+    @JsonIgnore
     private User writer;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "article_id", nullable = false)
+    @JsonIgnore
     private Article article;
 
     @Column(name = "content", nullable = false)
     private String content;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "parent_id")
-    private Comment parent;
+    @Column(name = "parent_id")
+    private Long parentId;
 
-    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "parentId", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> children = new ArrayList<>();
 
     @Column(name = "deleted_at", nullable = true)
     private LocalDateTime deletedAt;
 
+    public static Comment of(AddCommentRequest request, Article article, User user) {
+        return Comment.builder()
+            .writer(user)
+            .article(article)
+            .content(request.getContent())
+            .parentId(request.getParentId())
+            .build();
+    }
+
+    public void addChild(Comment comment) {
+        children.add(comment);
+    }
+
+    public void deleteChild() {
+        children.clear();
+    }
 }

--- a/src/main/java/org/example/weneedbe/domain/comment/dto/request/AddCommentRequest.java
+++ b/src/main/java/org/example/weneedbe/domain/comment/dto/request/AddCommentRequest.java
@@ -1,0 +1,10 @@
+package org.example.weneedbe.domain.comment.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class AddCommentRequest {
+
+  private long parentId;
+  private String content;
+}

--- a/src/main/java/org/example/weneedbe/domain/comment/exception/CommentNotFoundException.java
+++ b/src/main/java/org/example/weneedbe/domain/comment/exception/CommentNotFoundException.java
@@ -1,0 +1,10 @@
+package org.example.weneedbe.domain.comment.exception;
+
+import org.example.weneedbe.global.error.ErrorCode;
+import org.example.weneedbe.global.error.exception.ServiceException;
+
+public class CommentNotFoundException extends ServiceException {
+  public CommentNotFoundException() {
+    super(ErrorCode.COMMENT_NOT_FOUND);
+  }
+}

--- a/src/main/java/org/example/weneedbe/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/org/example/weneedbe/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,8 @@
+package org.example.weneedbe.domain.comment.repository;
+
+import org.example.weneedbe.domain.comment.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+}

--- a/src/main/java/org/example/weneedbe/global/error/ErrorCode.java
+++ b/src/main/java/org/example/weneedbe/global/error/ErrorCode.java
@@ -12,7 +12,8 @@ public enum ErrorCode {
     FILE_UPLOAD_ERROR(500, "FILE_UPLOAD_ERROR", "파일 업로드에 실패했습니다."),
     ARTICLE_NOT_FOUND(400, "ARTICLE_NOT_FOUND", "존재하지 않는 게시물입니다."),
     INVALID_TOKEN(401, "UNAUTHORIZED", "유효하지 않은 토큰입니다."),
-    EXPIRED_TOKEN(401,"UNAUTHORIZED", "만료된 토큰입니다.");
+    EXPIRED_TOKEN(401,"UNAUTHORIZED", "만료된 토큰입니다."),
+    COMMENT_NOT_FOUND(400, "COMMENT_NOT_FOUND", "존재하지 않는 댓글입니다.");
 
     private final int httpStatus;
     private final String code;

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,0 +1,37 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/weneed
+    username: root
+    password:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    show-sql: true
+    hibernate:
+      #valicate로 바꾸기
+      ddl-auto: create
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQLDialect
+    properties:
+      hibernate:
+        format_sql: true
+
+  servlet:
+    multipart:
+      max-file-size: 20MB # 파일 하나당 크기
+      max-request-size: 20MB # 전송하려는 총 파일 크기
+
+cloud:
+  aws:
+    credentials:
+      accessKey: ENC(ovlMiS3z8h4ibksrBpL1LTJIvDhaVUK88zQtSMYIkDw=)
+      secretKey: ENC(Xcox3M12b78LKg7nyEvHAVfJv586pGXDuNszoTXOdop5bJFWCiNwQSsJxJtgV5WGN/3yTGxlLUw=)
+    s3:
+      bucket: weneedbucket/files
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+
+jwt:
+  issuer: ENC(bbdtWueEsh7LW+PrGzB46UwfJKBJW8DMJcbn9cAkLrk=)
+  secret_key: ENC(3P9HeDamaRYl9h4zz9M7Vy7xoQZ23d4t)


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 댓글, 대댓글 작성 및 댓글 삭제 api를 구현하였습니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="801" alt="스크린샷 2024-01-13 오후 8 34 47" src="https://github.com/Leets-Official/WeNeed-BE/assets/123073840/32f427d8-8818-4579-8307-6cd5aa08c53e">
<img width="796" alt="스크린샷 2024-01-13 오후 8 35 20" src="https://github.com/Leets-Official/WeNeed-BE/assets/123073840/26df054f-4327-497d-9110-eaab46ca77bf">

<br>

## 4. 완료 사항
- 댓글 작성 api 및 댓글 삭제 api를 구현하였습니다.
- 대댓글 작성 및 삭제는 위의 api를 이용합니다.

- 대댓글 작성
1. request에 parentId와 content를 넣어 서버에 보냅니다.
2. parentId가 0이면 댓글, parentId가 commentId이면 commentId의 답글로 저장됩니다.

- 대댓글 삭제
1. commentId를 이용해 해당 댓글(답글)의 parentId가 0이면 부모댓글이므로 부모댓글과 하위 자식 댓글을 모두 제거합니다.
2. 그렇지 않으면 commentId의 답글만 제거합니다.
<br>

## 5. 추가 사항
close #16 