### PR TITLE
[feat] #32 학교 메일 인증 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven{url 'https://jitpack.io'}
 }
 
 dependencies {
@@ -37,6 +38,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation 'javax.xml.bind:jaxb-api:2.3.1'
 	implementation 'com.google.api-client:google-api-client:1.32.1'
+	implementation 'com.github.in-seo:univcert:master-SNAPSHOT'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/weneedbe/domain/user/api/UnivCertController.java
+++ b/src/main/java/org/example/weneedbe/domain/user/api/UnivCertController.java
@@ -1,4 +1,4 @@
-package org.example.weneedbe.global.univcert.api;
+package org.example.weneedbe.domain.user.api;
 
 import com.univcert.api.UnivCert;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/org/example/weneedbe/global/univcert/api/UnivCertController.java
+++ b/src/main/java/org/example/weneedbe/global/univcert/api/UnivCertController.java
@@ -1,2 +1,55 @@
-package org.example.weneedbe.global.univcert.api;public class UnivCertController {
+package org.example.weneedbe.global.univcert.api;
+
+import com.univcert.api.UnivCert;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.transaction.Transactional;
+import org.example.weneedbe.global.error.ErrorResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@Tag(name = "Mail Certification Controller", description = "메일 인증 관련 API입니다.")
+@RestController
+@RequestMapping("/api/v1")
+@Transactional
+public class UnivCertController {
+    private final static String UNIV_NAME = "가천대학교";
+    @Value("${univcertKey}")
+    String apiKey;
+    private String email;
+
+    @Operation(summary = "학교 메일 조회", description = "입력한 이메일이 가천대학교 소속 이메일인지 확인합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/certify")
+    public void checkMailWithUniv(@RequestParam String email) throws IOException {
+        this.email = email;
+        System.out.println(this.email);
+        UnivCert.certify(apiKey, email, UNIV_NAME, true);
+    }
+
+    @Operation(summary = "인증 코드 입력", description = "입력한 이메일에 발송한 입력 코드를 토대로 메일을 인증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/certifycode")
+    public void checkVerificationCode(@RequestParam int code) throws IOException {
+        UnivCert.certifyCode(apiKey, email, UNIV_NAME, code);
+    }
 }

--- a/src/main/java/org/example/weneedbe/global/univcert/api/UnivCertController.java
+++ b/src/main/java/org/example/weneedbe/global/univcert/api/UnivCertController.java
@@ -1,0 +1,2 @@
+package org.example.weneedbe.global.univcert.api;public class UnivCertController {
+}

--- a/src/main/java/org/example/weneedbe/global/univcert/api/UnivCertController.java
+++ b/src/main/java/org/example/weneedbe/global/univcert/api/UnivCertController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
 import org.example.weneedbe.global.error.ErrorResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,10 +22,11 @@ import java.io.IOException;
 @RestController
 @RequestMapping("/api/v1")
 @Transactional
+@Slf4j
 public class UnivCertController {
     private final static String UNIV_NAME = "가천대학교";
     @Value("${univcertKey}")
-    String apiKey;
+    private String apiKey;
     private String email;
 
     @Operation(summary = "학교 메일 조회", description = "입력한 이메일이 가천대학교 소속 이메일인지 확인합니다.")
@@ -37,7 +39,7 @@ public class UnivCertController {
     @PostMapping("/certify")
     public void checkMailWithUniv(@RequestParam String email) throws IOException {
         this.email = email;
-        System.out.println(this.email);
+        log.info("\nemail:{}", this.email);
         UnivCert.certify(apiKey, email, UNIV_NAME, true);
     }
 

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -44,3 +44,5 @@ cloud:
 jwt:
   issuer: ENC(bbdtWueEsh7LW+PrGzB46UwfJKBJW8DMJcbn9cAkLrk=)
   secret_key: ENC(3P9HeDamaRYl9h4zz9M7Vy7xoQZ23d4t)
+
+univcertKey: ENC(qv85ftlYv6nJRP/yWbWsLuFbZCsNQVzoHAs5ioRaG0StCAWs7XaPq8qiYvqkDte6)

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -45,3 +45,5 @@ cloud:
 jwt:
   issuer: ENC(bbdtWueEsh7LW+PrGzB46UwfJKBJW8DMJcbn9cAkLrk=)
   secret_key: ENC(3P9HeDamaRYl9h4zz9M7Vy7xoQZ23d4t)
+
+univcertKey: ENC(qv85ftlYv6nJRP/yWbWsLuFbZCsNQVzoHAs5ioRaG0StCAWs7XaPq8qiYvqkDte6)


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 회원가입 단계에서의 학교 메일 인증을 구현하기 위함입니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
- 존재하지 않는 메일은 코드 `certify` 메서드가 동작 가능하지만, 실제 코드 인증은 불가합니다.
<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="1427" alt="image" src="https://github.com/Leets-Official/WeNeed-BE/assets/129377887/ea559855-bba6-4a12-975e-fd5ea43661d4">

<img width="1414" alt="image" src="https://github.com/Leets-Official/WeNeed-BE/assets/129377887/3ae0cb95-4a7d-4845-95f3-4effcc442f03">

<img width="1229" alt="image" src="https://github.com/Leets-Official/WeNeed-BE/assets/129377887/417f3078-e47e-4c0d-a803-69803da726b8">

<br>

## 4. 완료 사항
- 가천대학교 메일 인증
- 인증 코드를 통한 실제 메일 소유주임을 확인
<br>

## 5. 추가 사항
close #26