### PR TITLE
[feat] #34 상세 정보 입력 api 구현

### DIFF
--- a/src/main/java/org/example/weneedbe/domain/user/api/UserInfoController.java
+++ b/src/main/java/org/example/weneedbe/domain/user/api/UserInfoController.java
@@ -1,8 +1,14 @@
 package org.example.weneedbe.domain.user.api;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.weneedbe.domain.user.service.UserService;
+import org.example.weneedbe.global.error.ErrorResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,8 +24,15 @@ import java.io.IOException;
 public class UserInfoController {
     private final UserService userService;
 
+    @Operation(summary = "닉네임 중복 여부 조회", description = "이미 존재하는 이메일이면 true, 아닐 경우 false를 반환합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
     @PostMapping("/checkNickname")
     public ResponseEntity<Boolean> checkNicknameDuplicate(@RequestParam String nickName) throws IOException {
-        return ResponseEntity.ok(userService.checkNicknameDuplicate);
+        return ResponseEntity.ok(userService.checkNicknameDuplicate(nickName));
     }
 }

--- a/src/main/java/org/example/weneedbe/domain/user/api/UserInfoController.java
+++ b/src/main/java/org/example/weneedbe/domain/user/api/UserInfoController.java
@@ -7,13 +7,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.example.weneedbe.domain.user.dto.request.UserInfoRequest;
 import org.example.weneedbe.domain.user.service.UserService;
 import org.example.weneedbe.global.error.ErrorResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 
@@ -34,5 +32,17 @@ public class UserInfoController {
     @PostMapping("/checkNickname")
     public ResponseEntity<Boolean> checkNicknameDuplicate(@RequestParam String nickName) throws IOException {
         return ResponseEntity.ok(userService.checkNicknameDuplicate(nickName));
+    }
+
+    @Operation(summary = "사용자 상세 정보 입력", description = "닉네임, 학년, 본전공, 복수전공(선택), 관심분야를 입력받습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/info")
+    public ResponseEntity<?> getUserInfo(@RequestBody UserInfoRequest request) throws IOException {
+        return ResponseEntity.ok(userService.getUserInfo(request));
     }
 }

--- a/src/main/java/org/example/weneedbe/domain/user/api/UserInfoController.java
+++ b/src/main/java/org/example/weneedbe/domain/user/api/UserInfoController.java
@@ -1,0 +1,25 @@
+package org.example.weneedbe.domain.user.api;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.example.weneedbe.domain.user.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@Tag(name = "User Information Controller", description = "유저 상세 정보 입력 관련 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user")
+public class UserInfoController {
+    private final UserService userService;
+
+    @PostMapping("/checkNickname")
+    public ResponseEntity<Boolean> checkNicknameDuplicate(@RequestParam String nickName) throws IOException {
+        return ResponseEntity.ok(userService.checkNicknameDuplicate);
+    }
+}

--- a/src/main/java/org/example/weneedbe/domain/user/api/UserInfoController.java
+++ b/src/main/java/org/example/weneedbe/domain/user/api/UserInfoController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.weneedbe.domain.user.dto.request.UserInfoRequest;
+import org.example.weneedbe.domain.user.dto.response.UserInfoResponse;
 import org.example.weneedbe.domain.user.service.UserService;
 import org.example.weneedbe.global.error.ErrorResponse;
 import org.springframework.http.ResponseEntity;
@@ -42,7 +43,7 @@ public class UserInfoController {
             @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PostMapping("/info")
-    public ResponseEntity<?> getUserInfo(@RequestBody UserInfoRequest request) throws IOException {
-        return ResponseEntity.ok(userService.getUserInfo(request));
+    public ResponseEntity<UserInfoResponse> getUserInfo(@RequestBody UserInfoRequest request) throws Exception {
+        return userService.getUserInfo(request);
     }
 }

--- a/src/main/java/org/example/weneedbe/domain/user/domain/Department.java
+++ b/src/main/java/org/example/weneedbe/domain/user/domain/Department.java
@@ -1,5 +1,6 @@
 package org.example.weneedbe.domain.user.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -84,4 +85,14 @@ public enum Department {
     없음("없음");
 
     private final String department;
+
+    @JsonCreator
+    public static Department from (String value) {
+        for (Department department : Department.values()) {
+            if (department.getDepartment().equals(value)) {
+                return department;
+            }
+        }
+        return 없음;
+    }
 }

--- a/src/main/java/org/example/weneedbe/domain/user/domain/Fields.java
+++ b/src/main/java/org/example/weneedbe/domain/user/domain/Fields.java
@@ -1,5 +1,6 @@
 package org.example.weneedbe.domain.user.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -13,4 +14,14 @@ public enum Fields {
     IT("IT");
 
     private final String fields;
+
+    @JsonCreator
+    public static Fields from (String value) {
+        for (Fields field : Fields.values()) {
+            if (field.getFields().equals(value)) {
+                return field;
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/org/example/weneedbe/domain/user/dto/request/UserInfoRequest.java
+++ b/src/main/java/org/example/weneedbe/domain/user/dto/request/UserInfoRequest.java
@@ -1,0 +1,14 @@
+package org.example.weneedbe.domain.user.dto.request;
+
+import lombok.Data;
+import org.example.weneedbe.domain.user.domain.Department;
+import org.example.weneedbe.domain.user.domain.Fields;
+
+@Data
+public class UserInfoRequest {
+    private String nickname;
+    private int userGrade;
+    private Department major;
+    private Department doubleMajor;
+    private Fields interestField;
+}

--- a/src/main/java/org/example/weneedbe/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/org/example/weneedbe/domain/user/dto/response/UserInfoResponse.java
@@ -1,0 +1,15 @@
+package org.example.weneedbe.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserInfoResponse {
+    private boolean result;
+    private String message;
+}

--- a/src/main/java/org/example/weneedbe/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/weneedbe/domain/user/repository/UserRepository.java
@@ -11,4 +11,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
    List<User> findAllByNicknameStartingWith(String nickname);
 
    Optional<User> findByEmail(String email);
+
+   boolean existsByNickname(String email);
 }

--- a/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
+++ b/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
@@ -10,6 +10,10 @@ public class UserService {
 
     private final UserRepository userRepository;
 
+    public Boolean checkNicknameDuplicate(String nickName) {
+        return userRepository.existsByNickname(nickName);
+    }
+
     @Autowired
     public UserService(UserRepository userRepository) {
         this.userRepository = userRepository;

--- a/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
+++ b/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
@@ -1,11 +1,17 @@
 package org.example.weneedbe.domain.user.service;
+import lombok.extern.slf4j.Slf4j;
 import org.example.weneedbe.domain.user.domain.User;
+import org.example.weneedbe.domain.user.dto.request.UserInfoRequest;
+import org.example.weneedbe.domain.user.dto.response.UserInfoResponse;
 import org.example.weneedbe.domain.user.repository.UserRepository;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 public class UserService {
 
     private final UserRepository userRepository;
@@ -27,5 +33,27 @@ public class UserService {
     public User findByEmail(String email) {
         return userRepository.findByEmail(email)
                 .orElseThrow(IllegalArgumentException::new);
+    }
+
+    public ResponseEntity<UserInfoResponse> getUserInfo(UserInfoRequest request) throws Exception {
+        try {
+            /* 토큰을 통한 user 객체를 불러옴 */
+            /* 아직 토큰이 없기 때문에 임시 객체를 사용 */
+            User mockUser = userRepository.findById(1L).orElseThrow();
+            mockUser = User.builder()
+                    .email(mockUser.getEmail())
+                    .major(request.getMajor())
+                    .doubleMajor(request.getDoubleMajor())
+                    .nickname(request.getNickname())
+                    .grade(request.getUserGrade())
+                    .interestField(request.getInterestField())
+                    .hasRegistered(true)
+                    .build();
+            userRepository.save(mockUser);
+        } catch (Exception e) {
+            log.info(e.getMessage());
+            throw e;
+        }
+        return new ResponseEntity<>(new UserInfoResponse(true, "상세 정보 입력 성공"), HttpStatus.OK);
     }
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 상세 정보를 입력받아 DB에 해당 유저의 상세 정보를 저장합니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="1420" alt="스크린샷 2024-01-20 오전 1 18 12" src="https://github.com/Leets-Official/WeNeed-BE/assets/129377887/83743df4-ea47-4426-bd60-036f73f8c20c">
<img width="1418" alt="스크린샷 2024-01-20 오전 1 20 31" src="https://github.com/Leets-Official/WeNeed-BE/assets/129377887/fcecb5e1-04e6-41a9-bd65-6f43f911bbc1">

<br>

## 4. 완료 사항
- 닉네임 중복 확인 api
- 상세 정보를 입력받아 DB에 저장한 후 결과를 반환하는 api

close #33 
<br>

## 5. 추가 사항
- 향후 유저 인증 방식을 새로 추가해야합니다.