### PR TITLE
[feat] #36 리크루팅 게시물 상세조회 api

### DIFF
--- a/src/main/java/org/example/weneedbe/domain/article/api/ArticleController.java
+++ b/src/main/java/org/example/weneedbe/domain/article/api/ArticleController.java
@@ -13,7 +13,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.example.weneedbe.domain.article.application.ArticleService;
 import org.example.weneedbe.domain.article.dto.request.AddArticleRequest;
-import org.example.weneedbe.domain.article.dto.response.DetailPortfolioDto;
+import org.example.weneedbe.domain.article.dto.response.DetailResponseDto.DetailPortfolioDto;
+import org.example.weneedbe.domain.article.dto.response.DetailResponseDto.DetailRecruitDto;
 import org.example.weneedbe.domain.article.dto.response.MemberInfoResponse;
 import org.example.weneedbe.global.error.ErrorResponse;
 import org.springframework.http.HttpStatus;
@@ -109,5 +110,17 @@ public class ArticleController {
     @GetMapping("/portfolio/{articleId}")
     public ResponseEntity<DetailPortfolioDto> detailPortfolio(@RequestHeader("Authorization") String authorizationHeader, @PathVariable Long articleId) {
         return ResponseEntity.ok(articleService.getDetailPortfolio(authorizationHeader, articleId));
+    }
+
+    @Operation(summary = "리크루팅 게시물 조회", description = "리크루팅부분에서 해당 게시물을 상세조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/recruit/{articleId}")
+    public ResponseEntity<DetailRecruitDto> detailRecruit(@RequestHeader("Authorization") String authorizationHeader, @PathVariable Long articleId) {
+        return ResponseEntity.ok(articleService.getDetailRecruit(authorizationHeader, articleId));
     }
 }

--- a/src/main/java/org/example/weneedbe/domain/article/dto/response/DetailResponseDto.java
+++ b/src/main/java/org/example/weneedbe/domain/article/dto/response/DetailResponseDto.java
@@ -3,6 +3,7 @@ package org.example.weneedbe.domain.article.dto.response;
 import lombok.*;
 import org.example.weneedbe.domain.article.domain.Article;
 import org.example.weneedbe.domain.article.domain.ContentData;
+import org.example.weneedbe.domain.comment.domain.Comment;
 import org.example.weneedbe.domain.file.domain.File;
 import org.example.weneedbe.domain.user.domain.Department;
 import org.example.weneedbe.domain.user.domain.User;
@@ -12,21 +13,28 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Getter
-@AllArgsConstructor
-public class DetailPortfolioDto {
-    private DetailUserDto user;
-    private DetailPortfolioArticleDto portfolio;
-    private List<WorkPortfolioArticleDto> workList;
 
-    public DetailPortfolioDto(Article article, User user, int heartCount, int bookmarkCount, List<Article> userPortfolio) {
-        this.user = new DetailUserDto(user, user.getUserId().equals(article.getUser().getUserId()));
-        this.portfolio = new DetailPortfolioArticleDto(article, heartCount, bookmarkCount);
-        this.workList = initializeWorkList(userPortfolio, article);
+public class DetailResponseDto {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class DetailPortfolioDto{
+
+        private DetailUserDto user;
+        private DetailArticleDto portfolio;
+        private List<WorkPortfolioArticleDto> workList;
+
+        public DetailPortfolioDto(Article article, User user, int heartCount, int bookmarkCount, List<Article> userPortfolio) {
+            this.user = new DetailUserDto(user, user.getUserId().equals(article.getUser().getUserId()));
+            this.portfolio = new DetailArticleDto(article, heartCount, bookmarkCount);
+            this.workList = initializeWorkList(userPortfolio, article);
+        }
     }
 
     @Getter
-    public class DetailUserDto {
+    public static class DetailUserDto {
         private String nickname;
         private boolean sameUser;
 
@@ -37,13 +45,14 @@ public class DetailPortfolioDto {
     }
 
     @Getter
-    public class DetailPortfolioArticleDto {
+    public static class DetailArticleDto {
         private String thumbnail;
         private String title;
         private LocalDateTime createdAt;
         private int heatCount;
         private int viewCount;
         private int bookmarkCount;
+        private int commentCount; //포트폴리오에도 추가
         private List<String> skills;
         private List<String> links;
         private List<String> tags;
@@ -51,7 +60,7 @@ public class DetailPortfolioDto {
         private DetailWriterPortfolioDto writer;
         private List<DetailPortfolioContentDto> contents;
 
-        public DetailPortfolioArticleDto(Article article, int heatCount, int bookmarkCount) {
+        public DetailArticleDto(Article article, int heatCount, int bookmarkCount) {
             this.thumbnail = article.getThumbnail();
             this.title = article.getTitle();
             this.createdAt = article.getCreatedAt();
@@ -69,7 +78,7 @@ public class DetailPortfolioDto {
         }
     }
 
-    private List<DetailPortfolioContentDto> getPortfolioContents(List<ContentData> contents) {
+    private static List<DetailPortfolioContentDto> getPortfolioContents(List<ContentData> contents) {
         List<DetailPortfolioContentDto> contentDtoList = new ArrayList<>();
         for (ContentData contentData : contents) {
             DetailPortfolioContentDto contentDto = new DetailPortfolioContentDto();
@@ -86,7 +95,7 @@ public class DetailPortfolioDto {
     }
 
     @Getter
-    public class DetailWriterPortfolioDto {
+    public static class DetailWriterPortfolioDto {
         private Long userId;
         private String writerNickname;
         private Department major;
@@ -104,7 +113,7 @@ public class DetailPortfolioDto {
 
     @Getter
     @Setter
-    public class DetailPortfolioContentDto {
+    public static class DetailPortfolioContentDto {
         private Long id;
         private String type;
         private String textData;
@@ -112,7 +121,7 @@ public class DetailPortfolioDto {
     }
 
     @Getter
-    public class WorkPortfolioArticleDto {
+    public static class WorkPortfolioArticleDto {
         private Long articleId;
         private String thumbnail;
         private String title;
@@ -124,7 +133,7 @@ public class DetailPortfolioDto {
         }
     }
 
-    private List<WorkPortfolioArticleDto> initializeWorkList(List<Article> userPortfolio, Article article) {
+    private static List<WorkPortfolioArticleDto> initializeWorkList(List<Article> userPortfolio, Article article) {
         List<WorkPortfolioArticleDto> workList = new ArrayList<>();
         for (Article portfolio : userPortfolio) {
             /* 상세조회하는 게시물 제외하고 workList에 추가 */
@@ -134,4 +143,37 @@ public class DetailPortfolioDto {
         }
         return workList;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class DetailRecruitDto{
+        private DetailUserDto user;
+        private DetailArticleDto recruit;
+        private CommentResponseDto comments;
+
+        public DetailRecruitDto(Article article, User user, int heartCount, int bookmarkCount, Comment comment) {
+            this.user = new DetailUserDto(user, user.getUserId().equals(article.getUser().getUserId()));
+            this.recruit = new DetailArticleDto(article, heartCount, bookmarkCount);
+            this.comments = new CommentResponseDto(comment);
+        }
+
+    }
+
+    @Getter
+    public static class CommentResponseDto{
+        private Long commentId;
+        private String content;
+        private List<CommentResponseDto> children;
+
+        public CommentResponseDto(Comment comment) {
+            this.commentId = comment.getCommentId();
+            this.content = comment.getContent();
+            this.children = comment.getChildren().stream()
+                    .map(CommentResponseDto::new)
+                    .collect(Collectors.toList());
+        }
+    }
+
 }

--- a/src/main/java/org/example/weneedbe/domain/article/repository/ArticleLikeRepository.java
+++ b/src/main/java/org/example/weneedbe/domain/article/repository/ArticleLikeRepository.java
@@ -13,4 +13,5 @@ public interface ArticleLikeRepository extends JpaRepository<ArticleLike, Long> 
 
     int countByArticle(Article article);
 
+    boolean existsByArticleAndUser(Article article, User user);
 }

--- a/src/main/java/org/example/weneedbe/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/org/example/weneedbe/domain/bookmark/repository/BookmarkRepository.java
@@ -11,4 +11,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     Optional<Bookmark> findByArticleAndUser(Article article, User user);
 
     int countByArticle(Article article);
+
+    boolean existsByArticleAndUser(Article article, User user);
 }

--- a/src/main/java/org/example/weneedbe/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/org/example/weneedbe/domain/comment/repository/CommentRepository.java
@@ -1,8 +1,12 @@
 package org.example.weneedbe.domain.comment.repository;
 
+import org.example.weneedbe.domain.article.domain.Article;
 import org.example.weneedbe.domain.comment.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    Optional<Comment> findAllByArticle(Article article);
 
 }

--- a/src/main/java/org/example/weneedbe/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/org/example/weneedbe/domain/comment/repository/CommentRepository.java
@@ -4,9 +4,8 @@ import org.example.weneedbe.domain.article.domain.Article;
 import org.example.weneedbe.domain.comment.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
+import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    Optional<Comment> findAllByArticle(Article article);
-
+    List<Comment> findAllByArticle(Article article);
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
리크루팅 게시물 상세조회 api를 구현합니다.

포트폴리오 게시물 상세조회와 리크루팅 게시물 상세조회의 response가 유사하여 하나의 `detailResponseDto` 클래스 안에 `detailPortfolioDto`, `detaiRecruitDto` 두가지를 함께 구현합니다. 

<br>

## 2. 어떤 위험이나 장애를 발견했나요?
포트폴리오 상세조회때 놓쳤던 부분을 같이 구현했습니다

<br>

## 3. 관련 스크린샷을 첨부해주세요.
![image](https://github.com/Leets-Official/WeNeed-BE/assets/108799865/eb2f0d8a-2278-403b-b5f6-aa9f167f2f68)
![image](https://github.com/Leets-Official/WeNeed-BE/assets/108799865/70490913-0a2e-4209-8f24-edfb286785d4)
![image](https://github.com/Leets-Official/WeNeed-BE/assets/108799865/30ee3aa8-b5be-4bd3-84e1-a713a91190ad)


<br>

## 4. 완료 사항

* 포트폴리오 상세조회 빠졌던 부분
- [x]  댓글리스트추가
- [x]  “나” 유저가 좋아요 했는지 여부, “나”유저가 북마크 했는지 여부 (user)
- [x] 팀원추가(userid, nickname, profile) (portfolio)
- [x] worklist : 각 게시물마다 “나” 유저가 북마크 했는지 여부 (worklist)

체크되지 않은 두가지는 다른 이슈로 추가하도록 하겠습니다.
=> 추가로직 완성했습니다.

<br>

## 5. 추가 사항
close #30
