### PR TITLE
[feat] #39 마이페이지 내정보 api 구현

### DIFF
--- a/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
+++ b/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
@@ -1,0 +1,38 @@
+package org.example.weneedbe.domain.user.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.example.weneedbe.domain.user.service.UserService;
+import org.example.weneedbe.global.error.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@Tag(name = "User MyPage Controller", description = "사용자의 마이페이지 관련 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user/myPage")
+public class MyPageController {
+    private final UserService userService;
+
+    @Operation(summary = "마이페이지의 내 정보", description = "현재 로그인한 사용자의 정보를 마이페이지 내 불러옵니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/getMyInfo")
+    public ResponseEntity<MyPageGetMyInfoResponse> getMyInfo(@RequestHeader("Authorization") String authorizationHeader) throws IOException {
+        return ResponseEntity.ok(userService.getMyInfo(authorizationHeader));
+    }
+}

--- a/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
+++ b/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.example.weneedbe.domain.user.dto.response.mypage.MyPageGetMyInfoResponse;
 import org.example.weneedbe.domain.user.service.UserService;
 import org.example.weneedbe.global.error.ErrorResponse;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/org/example/weneedbe/domain/user/domain/User.java
+++ b/src/main/java/org/example/weneedbe/domain/user/domain/User.java
@@ -73,4 +73,20 @@ public class User extends BaseTimeEntity {
 
         return this;
     }
+
+
+    public void getUserInfo(Department major,
+                            Department doubleMajor,
+                            String nickname,
+                            Integer grade,
+                            Fields interestField,
+                            Boolean hasRegistered) {
+
+        this.major = major;
+        this.doubleMajor = doubleMajor;
+        this.nickname = nickname;
+        this.grade = grade;
+        this.interestField = interestField;
+        this.hasRegistered = hasRegistered;
+    }
 }

--- a/src/main/java/org/example/weneedbe/domain/user/dto/response/mypage/MyPageGetMyInfoResponse.java
+++ b/src/main/java/org/example/weneedbe/domain/user/dto/response/mypage/MyPageGetMyInfoResponse.java
@@ -1,0 +1,24 @@
+package org.example.weneedbe.domain.user.dto.response.mypage;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.example.weneedbe.domain.user.domain.Department;
+import org.example.weneedbe.domain.user.domain.Fields;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MyPageGetMyInfoResponse {
+    private String profile;
+    private String nickname;
+    private Department major;
+    private int userGrade;
+    private Department doubleMajor;
+    private Fields interestField;
+    private String email;
+    private List<String> links;
+    private String selfIntro;
+}

--- a/src/main/java/org/example/weneedbe/domain/user/dto/response/mypage/MyPageGetMyInfoResponse.java
+++ b/src/main/java/org/example/weneedbe/domain/user/dto/response/mypage/MyPageGetMyInfoResponse.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import org.example.weneedbe.domain.user.domain.Department;
 import org.example.weneedbe.domain.user.domain.Fields;
+import org.example.weneedbe.domain.user.domain.User;
 
 import java.util.List;
 
@@ -21,4 +22,18 @@ public class MyPageGetMyInfoResponse {
     private String email;
     private List<String> links;
     private String selfIntro;
+
+    public static MyPageGetMyInfoResponse from(User user) {
+        return MyPageGetMyInfoResponse.builder()
+                .profile(user.getProfile())
+                .nickname(user.getNickname())
+                .major(user.getMajor())
+                .userGrade(user.getGrade())
+                .doubleMajor(user.getDoubleMajor())
+                .interestField(user.getInterestField())
+                .email(user.getEmail())
+                .links(user.getLinks())
+                .selfIntro(user.getAboutMe())
+                .build();
+    }
 }

--- a/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
+++ b/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
@@ -9,7 +9,6 @@ import org.example.weneedbe.domain.user.exception.UserNotFoundException;
 import org.example.weneedbe.domain.user.repository.UserRepository;
 
 import org.example.weneedbe.global.config.jwt.TokenProvider;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -41,15 +40,13 @@ public class UserService {
             /* 토큰을 통한 user 객체를 불러옴 */
             /* 아직 토큰이 없기 때문에 임시 객체를 사용 */
             User mockUser = userRepository.findById(1L).orElseThrow();
-            mockUser = User.builder()
-                    .email(mockUser.getEmail())
-                    .major(request.getMajor())
-                    .doubleMajor(request.getDoubleMajor())
-                    .nickname(request.getNickname())
-                    .grade(request.getUserGrade())
-                    .interestField(request.getInterestField())
-                    .hasRegistered(true)
-                    .build();
+            mockUser.getUserInfo(request.getMajor(),
+                    request.getDoubleMajor(),
+                    request.getNickname(),
+                    request.getUserGrade(),
+                    request.getInterestField(),
+                    true);
+
             userRepository.save(mockUser);
         } catch (Exception e) {
             log.info(e.getMessage());

--- a/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
+++ b/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
@@ -5,6 +5,7 @@ import org.example.weneedbe.domain.user.domain.User;
 import org.example.weneedbe.domain.user.dto.request.UserInfoRequest;
 import org.example.weneedbe.domain.user.dto.response.UserInfoResponse;
 import org.example.weneedbe.domain.user.dto.response.mypage.MyPageGetMyInfoResponse;
+import org.example.weneedbe.domain.user.exception.UserNotFoundException;
 import org.example.weneedbe.domain.user.repository.UserRepository;
 
 import org.example.weneedbe.global.config.jwt.TokenProvider;
@@ -55,5 +56,28 @@ public class UserService {
             throw e;
         }
         return new ResponseEntity<>(new UserInfoResponse(true, "상세 정보 입력 성공"), HttpStatus.OK);
+    }
+
+    public MyPageGetMyInfoResponse getMyInfo(String authorizationHeader) {
+        /* 토큰을 통한 user 객체를 불러옴 */
+        /* 아직 토큰이 없기 때문에 임시 객체를 사용 */
+/*        String token = tokenProvider.getTokenFromAuthorizationHeader(authorizationHeader);
+        Long userId = tokenProvider.getUserIdFromToken(token);
+
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);*/
+
+        User mockUser = userRepository.findById(1L).orElseThrow();
+
+        return MyPageGetMyInfoResponse.builder()
+                .profile(mockUser.getProfile())
+                .nickname(mockUser.getNickname())
+                .major(mockUser.getMajor())
+                .userGrade(mockUser.getGrade())
+                .doubleMajor(mockUser.getDoubleMajor())
+                .interestField(mockUser.getInterestField())
+                .email(mockUser.getEmail())
+                .links(mockUser.getLinks())
+                .selfIntro(mockUser.getAboutMe())
+                .build();
     }
 }

--- a/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
+++ b/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
@@ -1,10 +1,13 @@
 package org.example.weneedbe.domain.user.service;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.weneedbe.domain.user.domain.User;
 import org.example.weneedbe.domain.user.dto.request.UserInfoRequest;
 import org.example.weneedbe.domain.user.dto.response.UserInfoResponse;
+import org.example.weneedbe.domain.user.dto.response.mypage.MyPageGetMyInfoResponse;
 import org.example.weneedbe.domain.user.repository.UserRepository;
 
+import org.example.weneedbe.global.config.jwt.TokenProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,17 +15,14 @@ import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
+    private final TokenProvider tokenProvider;
 
     public Boolean checkNicknameDuplicate(String nickName) {
         return userRepository.existsByNickname(nickName);
-    }
-
-    @Autowired
-    public UserService(UserRepository userRepository) {
-        this.userRepository = userRepository;
     }
 
     public User findById(Long userId) {

--- a/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
+++ b/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
@@ -65,16 +65,7 @@ public class UserService {
 
         User mockUser = userRepository.findById(1L).orElseThrow();
 
-        return MyPageGetMyInfoResponse.builder()
-                .profile(mockUser.getProfile())
-                .nickname(mockUser.getNickname())
-                .major(mockUser.getMajor())
-                .userGrade(mockUser.getGrade())
-                .doubleMajor(mockUser.getDoubleMajor())
-                .interestField(mockUser.getInterestField())
-                .email(mockUser.getEmail())
-                .links(mockUser.getLinks())
-                .selfIntro(mockUser.getAboutMe())
-                .build();
+        return MyPageGetMyInfoResponse.from(mockUser);
+
     }
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 마이페이지 내 사용자 정보를 불러오는 API를 구현했습니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
- 토큰을 활용한 테스트가 불가능하여 mockUser을 통해 테스트하였습니다.
- 상세 정보를 입력하는 부분에서 유저가 DB에 중복으로 생성되는 오류를 발견해 수정하였습니다.
<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="1361" alt="스크린샷 2024-01-20 오후 6 20 24" src="https://github.com/Leets-Official/WeNeed-BE/assets/129377887/f0b4aca4-b47b-4ada-9431-c57af66a2a51">

<br>

## 4. 완료 사항
- 상세 정보 입력시 유저 중복 생성 오류 해결
- 마이페이지 내 로그인한 사용자의 정보를 불러오는 API 구현
close #35 
<br>

## 5. 추가 사항
- 내 정보 수정 API를 이어서 구현할 예정입니다.