### PR TITLE
[feat] #44 관심 크루 조회 api 구현

### DIFF
--- a/src/main/java/org/example/weneedbe/domain/bookmark/domain/Bookmark.java
+++ b/src/main/java/org/example/weneedbe/domain/bookmark/domain/Bookmark.java
@@ -3,6 +3,7 @@ package org.example.weneedbe.domain.bookmark.domain;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.weneedbe.domain.article.domain.Article;
 import org.example.weneedbe.domain.user.domain.User;
@@ -10,6 +11,7 @@ import org.example.weneedbe.domain.user.domain.User;
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
+@Getter
 @Builder
 @Table(name="bookmark")
 public class Bookmark {

--- a/src/main/java/org/example/weneedbe/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/org/example/weneedbe/domain/bookmark/repository/BookmarkRepository.java
@@ -1,8 +1,10 @@
 package org.example.weneedbe.domain.bookmark.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.example.weneedbe.domain.article.domain.Article;
+import org.example.weneedbe.domain.article.domain.Type;
 import org.example.weneedbe.domain.bookmark.domain.Bookmark;
 import org.example.weneedbe.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,4 +15,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     int countByArticle(Article article);
 
     boolean existsByArticleAndUser(Article article, User user);
+
+    List<Bookmark> findAllByUserAndArticle_ArticleTypeOrderByArticle_CreatedAtDesc(User user, Type articleType);
 }

--- a/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
+++ b/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
@@ -6,7 +6,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.example.weneedbe.domain.user.dto.response.mypage.MyPageArticleInfoResponse;
 import org.example.weneedbe.domain.user.dto.response.mypage.MyPageGetMyInfoResponse;
 import org.example.weneedbe.domain.user.service.UserService;
 import org.example.weneedbe.global.error.ErrorResponse;
@@ -23,17 +25,32 @@ import java.io.IOException;
 @RequiredArgsConstructor
 @RequestMapping("/user/myPage")
 public class MyPageController {
+
     private final UserService userService;
 
     @Operation(summary = "마이페이지의 내 정보", description = "현재 로그인한 사용자의 정보를 마이페이지 내 불러옵니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+        @ApiResponse(responseCode = "200"),
+        @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping("/getMyInfo")
-    public ResponseEntity<MyPageGetMyInfoResponse> getMyInfo(@RequestHeader("Authorization") String authorizationHeader) throws IOException {
+    public ResponseEntity<MyPageGetMyInfoResponse> getMyInfo(
+        @RequestHeader("Authorization") String authorizationHeader) throws IOException {
         return ResponseEntity.ok(userService.getMyInfo(authorizationHeader));
+    }
+
+    @Operation(summary = "마이페이지의 관심 크루 조회", description = "사용자가 북마크한 팀원모집 게시물을 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200"),
+        @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/find-interesting-crews")
+    public ResponseEntity<List<MyPageArticleInfoResponse>> getInterestingCrewInfo(
+        @RequestHeader("Authorization") String authorizationHeader) {
+        return ResponseEntity.ok(userService.getInterestingCrewInfo(authorizationHeader));
     }
 }

--- a/src/main/java/org/example/weneedbe/domain/user/dto/response/mypage/MyPageArticleInfoResponse.java
+++ b/src/main/java/org/example/weneedbe/domain/user/dto/response/mypage/MyPageArticleInfoResponse.java
@@ -1,7 +1,7 @@
 package org.example.weneedbe.domain.user.dto.response.mypage;
 
 import lombok.Getter;
-import org.example.weneedbe.domain.bookmark.domain.Bookmark;
+import org.example.weneedbe.domain.article.domain.Article;
 
 @Getter
 public class MyPageArticleInfoResponse {
@@ -12,11 +12,11 @@ public class MyPageArticleInfoResponse {
   private int viewCount;
   private int heartCount;
 
-  public MyPageArticleInfoResponse(Bookmark bookmark, int heartCount) {
-    this.articleId = bookmark.getBookmarkId();
-    this.thumbnail = bookmark.getArticle().getThumbnail();
-    this.title = bookmark.getArticle().getTitle();
-    this.viewCount = bookmark.getArticle().getViewCount();
+  public MyPageArticleInfoResponse(Article article, int heartCount) {
+    this.articleId = article.getArticleId();
+    this.thumbnail = article.getThumbnail();
+    this.title = article.getTitle();
+    this.viewCount = article.getViewCount();
     this.heartCount = heartCount;
   }
 }

--- a/src/main/java/org/example/weneedbe/domain/user/dto/response/mypage/MyPageArticleInfoResponse.java
+++ b/src/main/java/org/example/weneedbe/domain/user/dto/response/mypage/MyPageArticleInfoResponse.java
@@ -1,0 +1,22 @@
+package org.example.weneedbe.domain.user.dto.response.mypage;
+
+import lombok.Getter;
+import org.example.weneedbe.domain.bookmark.domain.Bookmark;
+
+@Getter
+public class MyPageArticleInfoResponse {
+
+  private Long articleId;
+  private String thumbnail;
+  private String title;
+  private int viewCount;
+  private int heartCount;
+
+  public MyPageArticleInfoResponse(Bookmark bookmark, int heartCount) {
+    this.articleId = bookmark.getBookmarkId();
+    this.thumbnail = bookmark.getArticle().getThumbnail();
+    this.title = bookmark.getArticle().getTitle();
+    this.viewCount = bookmark.getArticle().getViewCount();
+    this.heartCount = heartCount;
+  }
+}

--- a/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
+++ b/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
@@ -1,11 +1,19 @@
 package org.example.weneedbe.domain.user.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.weneedbe.domain.article.domain.Article;
+import org.example.weneedbe.domain.article.domain.Type;
+import org.example.weneedbe.domain.article.repository.ArticleLikeRepository;
+import org.example.weneedbe.domain.bookmark.domain.Bookmark;
+import org.example.weneedbe.domain.bookmark.repository.BookmarkRepository;
 import org.example.weneedbe.domain.user.domain.User;
 import org.example.weneedbe.domain.user.dto.request.UserInfoRequest;
 import org.example.weneedbe.domain.user.dto.response.UserInfoResponse;
+import org.example.weneedbe.domain.user.dto.response.mypage.MyPageArticleInfoResponse;
 import org.example.weneedbe.domain.user.dto.response.mypage.MyPageGetMyInfoResponse;
+import org.example.weneedbe.domain.user.exception.UserNotFoundException;
 import org.example.weneedbe.domain.user.repository.UserRepository;
 import org.example.weneedbe.global.jwt.TokenProvider;
 import org.springframework.http.HttpStatus;
@@ -19,6 +27,8 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final TokenProvider tokenProvider;
+    private final BookmarkRepository bookmarkRepository;
+    private final ArticleLikeRepository articleLikeRepository;
 
     public Boolean checkNicknameDuplicate(String nickName) {
         return userRepository.existsByNickname(nickName);
@@ -66,5 +76,21 @@ public class UserService {
 
         return MyPageGetMyInfoResponse.from(mockUser);
 
+    }
+
+    public List<MyPageArticleInfoResponse> getInterestingCrewInfo(String authorizationHeader) {
+        Long userId = getUserIdFromHeader(authorizationHeader);
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+
+        List<Bookmark> recruitingBookmarks = bookmarkRepository.findAllByUserAndArticle_ArticleTypeOrderByArticle_CreatedAtDesc(
+            user, Type.RECRUITING);
+
+        return recruitingBookmarks.stream().map(s -> new MyPageArticleInfoResponse(s,
+            articleLikeRepository.countByArticle(s.getArticle()))).toList();
+    }
+
+    private Long getUserIdFromHeader(String authorizationHeader) {
+        String token = tokenProvider.getTokenFromAuthorizationHeader(authorizationHeader);
+        return tokenProvider.getUserIdFromToken(token);
     }
 }

--- a/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
+++ b/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
@@ -3,7 +3,6 @@ package org.example.weneedbe.domain.user.service;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.example.weneedbe.domain.article.domain.Article;
 import org.example.weneedbe.domain.article.domain.Type;
 import org.example.weneedbe.domain.article.repository.ArticleLikeRepository;
 import org.example.weneedbe.domain.bookmark.domain.Bookmark;
@@ -85,7 +84,7 @@ public class UserService {
         List<Bookmark> recruitingBookmarks = bookmarkRepository.findAllByUserAndArticle_ArticleTypeOrderByArticle_CreatedAtDesc(
             user, Type.RECRUITING);
 
-        return recruitingBookmarks.stream().map(s -> new MyPageArticleInfoResponse(s,
+        return recruitingBookmarks.stream().map(s -> new MyPageArticleInfoResponse(s.getArticle(),
             articleLikeRepository.countByArticle(s.getArticle()))).toList();
     }
 


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 사용자가 북마크한 팀원모집 게시물을 조회하는 api를 구현했습니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
![스크린샷 2024-01-21 오후 6 59 12](https://github.com/Leets-Official/WeNeed-BE/assets/123073840/33829550-13f9-4635-bb58-04b936f1f2a4)

<br>

## 4. 완료 사항
- 마이페이지에서 북마크한 팀원모집 게시물을 최신순으로 정렬하는 api를 구현하였습니다.
<br>

## 5. 추가 사항
- 게시물 리스트를 최신순으로 정렬하였습니다.
- 마이페이지에서 게시물 리스트를 조회하는 dto는 `MyPageArticleInfoResponse` dto를 공통적으로 사용하면 될 것 같습니다.
- articleField에 따라 분류하는 것을 상의해봐야합니다.
- 총 개수를 백엔드에서 전해줄지, 프론트에서 처리할지 상의해봐야합니다.
close #42 