### PR TITLE
[fix] #46 메인페이지 로그인 유무에 따른 로직 변경

### DIFF
--- a/src/main/java/org/example/weneedbe/domain/article/api/MainController.java
+++ b/src/main/java/org/example/weneedbe/domain/article/api/MainController.java
@@ -12,11 +12,7 @@ import org.example.weneedbe.domain.article.dto.response.main.MainPortfolioDto;
 import org.example.weneedbe.domain.article.dto.response.main.MainRecruitDto;
 import org.example.weneedbe.global.error.ErrorResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Objects;
 
 @Tag(name = "Main Controller", description = "메인페이지 관련 API입니다.")
 @RestController
@@ -47,7 +43,8 @@ public class MainController {
     })
     @GetMapping("/recruit")
     ResponseEntity<MainRecruitDto> getMainPageRecruit(
-            @RequestParam int size, @RequestParam int page, @RequestParam String[] detailTags) {
-        return ResponseEntity.ok(mainService.getRecruitArticleList(size, page, detailTags));
+            @RequestParam int size, @RequestParam int page, @RequestParam(required = false, defaultValue = "") String[] detailTags,
+            @RequestHeader(name = "Authorization", required = false)  String authorizationHeader) {
+        return ResponseEntity.ok(mainService.getRecruitArticleList(size, page, detailTags, authorizationHeader));
     }
 }

--- a/src/main/java/org/example/weneedbe/domain/article/api/MainController.java
+++ b/src/main/java/org/example/weneedbe/domain/article/api/MainController.java
@@ -12,7 +12,11 @@ import org.example.weneedbe.domain.article.dto.response.main.MainPortfolioDto;
 import org.example.weneedbe.domain.article.dto.response.main.MainRecruitDto;
 import org.example.weneedbe.global.error.ErrorResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Objects;
 
 @Tag(name = "Main Controller", description = "메인페이지 관련 API입니다.")
 @RestController
@@ -29,8 +33,9 @@ public class MainController {
     })
     @GetMapping("/portfolio")
     ResponseEntity<MainPortfolioDto> getMainPagePortfolio(
-            @RequestParam int size, @RequestParam int page, @RequestParam String sort, @RequestParam String[] detailTags) {
-        return ResponseEntity.ok(mainService.getPortfolioArticleList(size, page, sort, detailTags));
+            @RequestParam int size, @RequestParam int page, @RequestParam String sort, @RequestParam(required = false, defaultValue = "") String[] detailTags,
+            @RequestHeader(name = "Authorization", required = false)  String authorizationHeader) {
+        return ResponseEntity.ok(mainService.getPortfolioArticleList(size, page, sort, detailTags, authorizationHeader));
     }
 
     @Operation(summary = "메인페이지 - 리크루팅", description = "메인페이지에서 리크루팅 조회합니다")

--- a/src/main/java/org/example/weneedbe/domain/article/application/MainService.java
+++ b/src/main/java/org/example/weneedbe/domain/article/application/MainService.java
@@ -1,7 +1,6 @@
 package org.example.weneedbe.domain.article.application;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.example.weneedbe.domain.article.domain.Article;
 import org.example.weneedbe.domain.article.domain.ContentData;
 import org.example.weneedbe.domain.article.dto.response.main.*;
@@ -27,7 +26,6 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class MainService {
     private final UserRepository userRepository;
     private final ArticleRepository articleRepository;
@@ -142,15 +140,21 @@ public class MainService {
                 .build();
     }
 
-    public MainRecruitDto getRecruitArticleList(int size, int page, String[] detailTags) {
-        User mockUser = userRepository.findById(1L).orElseThrow(UserNotFoundException::new);
+    public MainRecruitDto getRecruitArticleList(int size, int page, String[] detailTags, String authorizationHeader) {
+        User user = null;
+        String guestNickname = "guest";
+
+        if (authorizationHeader != null) {
+            user = getUserFromAuthorizationHeader(authorizationHeader);
+        }
+
         Pageable pageable = PageRequest.of(page - 1, size);
         Page<Article> recruitingPage = articleRepository.findRecruitingByDetailTagsInOrderByCreatedAtDesc(detailTags, pageable);
         PageableDto pageableDto = new PageableDto(size, page, recruitingPage.getTotalPages(), recruitingPage.getTotalElements());
 
         List<RecruitArticleDto> recruitList = convertToRecruitArticleDtoList(recruitingPage.getContent());
 
-        return new MainRecruitDto(new MainUserDto(mockUser.getNickname()), pageableDto, recruitList);
+        return new MainRecruitDto(new MainUserDto(user != null ? user.getNickname() : guestNickname), pageableDto, recruitList);
     }
 
     private List<RecruitArticleDto> convertToRecruitArticleDtoList(List<Article> articles) {

--- a/src/main/java/org/example/weneedbe/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/org/example/weneedbe/domain/article/repository/ArticleRepository.java
@@ -13,8 +13,8 @@ import java.util.List;
 @Repository
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 
-    @Query(value = "SELECT a.* FROM article a INNER JOIN detail_tags dt ON a.article_id = dt.article_id WHERE a.article_type = 'PORTFOLIO' AND dt.detail_tags IN :detailTags ORDER BY a.created_at DESC",
-            countQuery = "SELECT count(*) FROM article a INNER JOIN detail_tags dt ON a.article_id = dt.article_id WHERE a.article_type = 'PORTFOLIO' AND dt.detail_tags IN :detailTags",
+    @Query(value = "SELECT a.* FROM article a LEFT JOIN detail_tags dt ON a.article_id = dt.article_id AND a.article_type = 'PORTFOLIO' AND (:detailTags IS NULL OR dt.detail_tags IN :detailTags) ORDER BY a.created_at DESC",
+            countQuery = "SELECT count(*) FROM article a LEFT JOIN detail_tags dt ON a.article_id = dt.article_id AND a.article_type = 'PORTFOLIO' AND (:detailTags IS NULL OR dt.detail_tags IN :detailTags)",
             nativeQuery = true)
     Page<Article> findPortfoliosByDetailTagsInOrderByCreatedAtDesc(@Param("detailTags") String[] detailTags, Pageable pageable);
 
@@ -22,19 +22,19 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
             "FROM article ar " +
             "LEFT JOIN detail_tags dt ON ar.article_id = dt.article_id " +
             "LEFT JOIN article_like h ON ar.article_id = h.article_id " +
-            "WHERE ar.article_type = 'PORTFOLIO' AND dt.detail_tags IN :detailTags " +
+            "WHERE ar.article_type = 'PORTFOLIO' AND (:detailTags IS NULL OR dt.detail_tags IN :detailTags)" +
             "GROUP BY ar.article_id " +
             "ORDER BY COUNT(h.article_id) DESC",
             countQuery = "SELECT COUNT(DISTINCT ar.article_id) " +
                     "FROM article ar " +
                     "LEFT JOIN detail_tags dt ON ar.article_id = dt.article_id " +
                     "LEFT JOIN article_like h ON ar.article_id = h.article_id " +
-                    "WHERE ar.article_type = 'PORTFOLIO' AND dt.detail_tags IN :detailTags",
+                    "WHERE ar.article_type = 'PORTFOLIO' AND (:detailTags IS NULL OR dt.detail_tags IN :detailTags)",
             nativeQuery = true)
     Page<Article> findPortfoliosByDetailTagsOrderByLikesDesc(@Param("detailTags") String[] detailTags, Pageable pageable);
 
-    @Query(value = "SELECT a.* FROM article a INNER JOIN detail_tags dt ON a.article_id = dt.article_id WHERE a.article_type = 'PORTFOLIO' AND dt.detail_tags IN :detailTags ORDER BY a.view_count DESC",
-            countQuery = "SELECT count(*) FROM article a INNER JOIN detail_tags dt ON a.article_id = dt.article_id WHERE a.article_type = 'PORTFOLIO' AND dt.detail_tags IN :detailTags",
+    @Query(value = "SELECT a.* FROM article a LEFT JOIN detail_tags dt ON a.article_id = dt.article_id AND a.article_type = 'PORTFOLIO' AND (:detailTags IS NULL OR dt.detail_tags IN :detailTags) ORDER BY a.view_count DESC",
+            countQuery = "SELECT count(*) FROM article a LEFT JOIN detail_tags dt ON a.article_id = dt.article_id AND a.article_type = 'PORTFOLIO' AND (:detailTags IS NULL OR dt.detail_tags IN :detailTags)",
             nativeQuery = true)
     Page<Article> findPortfoliosByDetailTagsInOrderByViewCountDesc(@Param("detailTags") String[] detailTags, Pageable pageable);
 
@@ -44,8 +44,8 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     @Query("SELECT ar FROM Article ar WHERE ar.articleType = 'PORTFOLIO'")
     List<Article> findPortfolios();
 
-    @Query(value = "SELECT a.* FROM article a INNER JOIN detail_tags dt ON a.article_id = dt.article_id WHERE a.article_type = 'RECRUITING' AND dt.detail_tags IN :detailTags ORDER BY a.created_at DESC",
-            countQuery = "SELECT count(*) FROM article a INNER JOIN detail_tags dt ON a.article_id = dt.article_id WHERE a.article_type = 'RECRUITING' AND dt.detail_tags IN :detailTags",
+    @Query(value = "SELECT a.* FROM article a INNER JOIN detail_tags dt ON a.article_id = dt.article_id WHERE a.article_type = 'RECRUITING' AND (:detailTags IS NULL OR dt.detail_tags IN :detailTags) ORDER BY a.created_at DESC",
+            countQuery = "SELECT count(*) FROM article a INNER JOIN detail_tags dt ON a.article_id = dt.article_id WHERE a.article_type = 'RECRUITING' AND (:detailTags IS NULL OR dt.detail_tags IN :detailTags)",
             nativeQuery = true)
     Page<Article> findRecruitingByDetailTagsInOrderByCreatedAtDesc(@Param("detailTags") String[] detailTags, Pageable pageable);
 

--- a/src/main/java/org/example/weneedbe/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/org/example/weneedbe/domain/article/repository/ArticleRepository.java
@@ -44,8 +44,8 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     @Query("SELECT ar FROM Article ar WHERE ar.articleType = 'PORTFOLIO'")
     List<Article> findPortfolios();
 
-    @Query(value = "SELECT a.* FROM article a INNER JOIN detail_tags dt ON a.article_id = dt.article_id WHERE a.article_type = 'RECRUITING' AND (:detailTags IS NULL OR dt.detail_tags IN :detailTags) ORDER BY a.created_at DESC",
-            countQuery = "SELECT count(*) FROM article a INNER JOIN detail_tags dt ON a.article_id = dt.article_id WHERE a.article_type = 'RECRUITING' AND (:detailTags IS NULL OR dt.detail_tags IN :detailTags)",
+    @Query(value = "SELECT a.* FROM article a LEFT JOIN detail_tags dt ON a.article_id = dt.article_id AND a.article_type = 'RECRUITING' AND (:detailTags IS NULL OR dt.detail_tags IN :detailTags) ORDER BY a.created_at DESC",
+            countQuery = "SELECT count(*) FROM article a LEFT JOIN detail_tags dt ON a.article_id = dt.article_id AND a.article_type = 'RECRUITING' AND (:detailTags IS NULL OR dt.detail_tags IN :detailTags)",
             nativeQuery = true)
     Page<Article> findRecruitingByDetailTagsInOrderByCreatedAtDesc(@Param("detailTags") String[] detailTags, Pageable pageable);
 

--- a/src/main/java/org/example/weneedbe/domain/user/exception/UserNotRegisteredException.java
+++ b/src/main/java/org/example/weneedbe/domain/user/exception/UserNotRegisteredException.java
@@ -1,0 +1,10 @@
+package org.example.weneedbe.domain.user.exception;
+
+import org.example.weneedbe.global.error.ErrorCode;
+import org.example.weneedbe.global.error.exception.ServiceException;
+
+public class UserNotRegisteredException extends ServiceException {
+  public UserNotRegisteredException() {
+    super(ErrorCode.USER_NOT_FOUND);
+  }
+}

--- a/src/main/java/org/example/weneedbe/global/error/ErrorCode.java
+++ b/src/main/java/org/example/weneedbe/global/error/ErrorCode.java
@@ -16,7 +16,8 @@ public enum ErrorCode {
     COMMENT_NOT_FOUND(400, "COMMENT_NOT_FOUND", "존재하지 않는 댓글입니다."),
     INVALID_SORT_ERROR(400, "INVALID_SORT_ERROR", "잘못된 정렬 값입니다."),
     INVALID_INPUT_VALUE(400, "INVALID_INPUT_VALUE", "유효하지 않은 입력값입니다."),
-    INVALID_EDIT_VALUE(400, "INVALID_EDIT_VALUE", "유효하지 않은 변경값입니다.");
+    INVALID_EDIT_VALUE(400, "INVALID_EDIT_VALUE", "유효하지 않은 변경값입니다."),
+    USER_NOT_REGISTERED(400, "USER_NOT_REGISTERED","회원가입이 완료되지 않은 유저입니다.");
 
     private final int httpStatus;
     private final String code;


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
메인페이지에서 비로그인자, 로그인자를 구별하여 데이터를 다르게 반환합니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?
-유저가 소셜로그인 후 상세정보 입력 안할시 `UserNotRegisteredException`을 발생시킵니다.
-이는 스프링부트 내 에러발생이므로 프론트에게 해당 에러를 전달해주어야합니다.

<br>

## 3. 관련 스크린샷을 첨부해주세요.
<포트폴리오> - 헤더없을시
![image](https://github.com/Leets-Official/WeNeed-BE/assets/108799865/1ed4ef0a-0e9e-459b-b647-79ae8f53a0a8)

<리크루팅> - 헤더없을시
![image](https://github.com/Leets-Official/WeNeed-BE/assets/108799865/062abaf9-ca7d-4595-b4e7-7d041a02628e)

<br>

## 4. 완료 사항
- [x] 포트폴리오 - 헤더 토큰 유무로 nickname(guest) 수정해서 반환
- [x] 포트폴리오 - 헤더 토큰 없을시 : articleList(bookmarked), recommendList(bookmarked) 모두 디폴트값 false로
- [x] 리크루팅 - 헤더 토큰 유무로 nickname(guest)수정해서 반환
- [x] 유저상세정보 비입력시 에러메시지와 코드를 함께 반환

<br>

## 5. 추가 사항
close #38 
