### PR TITLE
[feat] #48 게시물 상세조회시 댓글유저의 정보 및 북마크여부 추가

### DIFF
--- a/src/main/java/org/example/weneedbe/domain/article/application/ArticleService.java
+++ b/src/main/java/org/example/weneedbe/domain/article/application/ArticleService.java
@@ -12,7 +12,7 @@ import org.example.weneedbe.domain.article.domain.ArticleLike;
 import org.example.weneedbe.domain.article.dto.request.AddArticleRequest;
 import org.example.weneedbe.domain.article.dto.response.DetailResponseDto.DetailPortfolioDto;
 import org.example.weneedbe.domain.article.dto.response.DetailResponseDto.CommentResponseDto;
-
+import org.example.weneedbe.domain.article.dto.response.DetailResponseDto.WorkPortfolioArticleDto;
 import org.example.weneedbe.domain.article.dto.response.DetailResponseDto.DetailRecruitDto;
 import org.example.weneedbe.domain.article.dto.response.MemberInfoResponse;
 import org.example.weneedbe.domain.article.exception.ArticleNotFoundException;
@@ -140,12 +140,24 @@ public class ArticleService {
         boolean isHearted = articleLikeRepository.existsByArticleAndUser(article, user);
         boolean isBookmarked = bookmarkRepository.existsByArticleAndUser(article, user);
 
-        List<Article> portfolioArticlesByUserId = articleRepository.findPortfolioArticlesByUserId(user.getUserId());
-
+        List<Article> portfolioArticlesByUser = articleRepository.findPortfolioArticlesByUser(article.getUser());
         List<Comment> commentList = commentRepository.findAllByArticle(article);
         List<CommentResponseDto> commentResponseDtos = mapToResponseDto(commentList);
 
-        return new DetailPortfolioDto(article, user, heartCount, bookmarkCount, portfolioArticlesByUserId, isHearted, isBookmarked, commentResponseDtos);
+        List<WorkPortfolioArticleDto> workList = initializeWorkList(portfolioArticlesByUser, article, user);
+
+        return new DetailPortfolioDto(article, user, heartCount, bookmarkCount, workList, isHearted, isBookmarked, commentResponseDtos);
+    }
+    private List<WorkPortfolioArticleDto> initializeWorkList(List<Article> userPortfolio, Article article, User user) {
+        List<WorkPortfolioArticleDto> workList = new ArrayList<>();
+        for (Article portfolio : userPortfolio) {
+            /* 상세조회하는 게시물 제외하고 workList에 추가 */
+            if (!portfolio.getArticleId().equals(article.getArticleId())) {
+                boolean bookmarked = bookmarkRepository.existsByArticleAndUser(portfolio, user);
+                workList.add(new WorkPortfolioArticleDto(portfolio, bookmarked));
+            }
+        }
+        return workList;
     }
 
     private Long getUserIdFromAuthorizationHeader(String authorizationHeader) {

--- a/src/main/java/org/example/weneedbe/domain/article/dto/response/DetailResponseDto.java
+++ b/src/main/java/org/example/weneedbe/domain/article/dto/response/DetailResponseDto.java
@@ -176,11 +176,23 @@ public class DetailResponseDto {
     public static class CommentResponseDto {
         private Long commentId;
         private String content;
+        private Long userId;
+        private String nickname;
+        private Department major;
+        private Integer grade;
+        private LocalDateTime createdAt;
+        private String profile;
         private List<CommentResponseDto> children;
 
         public CommentResponseDto(Comment comment, List<Comment> commentList) {
             this.commentId = comment.getCommentId();
             this.content = comment.getContent();
+            this.userId = comment.getWriter().getUserId();
+            this.nickname = comment.getWriter().getNickname();
+            this.major = comment.getWriter().getMajor();
+            this.grade = comment.getWriter().getGrade();
+            this.createdAt = comment.getCreatedAt();
+            this.profile = comment.getWriter().getProfile();
             if (!comment.getChildren().isEmpty()) {
                 this.children = comment.getChildren().stream()
                         .map(child -> new CommentResponseDto(child, commentList))

--- a/src/main/java/org/example/weneedbe/domain/article/dto/response/DetailResponseDto.java
+++ b/src/main/java/org/example/weneedbe/domain/article/dto/response/DetailResponseDto.java
@@ -7,6 +7,7 @@ import org.example.weneedbe.domain.comment.domain.Comment;
 import org.example.weneedbe.domain.file.domain.File;
 import org.example.weneedbe.domain.user.domain.Department;
 import org.example.weneedbe.domain.user.domain.User;
+import org.example.weneedbe.domain.user.domain.UserArticle;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -67,6 +68,7 @@ public class DetailResponseDto {
         private List<String> files;
         private DetailWriterDto writer;
         private List<DetailPortfolioContentDto> contents;
+        private List<DetailTeamMemberDto> teamMembers;
 
         public DetailArticleDto(Article article, int heatCount, int bookmarkCount) {
             this.thumbnail = article.getThumbnail();
@@ -84,6 +86,9 @@ public class DetailResponseDto {
                     .collect(Collectors.toList());
             this.writer = new DetailWriterDto(article);
             this.contents = getPortfolioContents(article.getContent());
+            this.teamMembers = article.getUserArticles().stream()
+                    .map(userArticle -> new DetailTeamMemberDto(userArticle.getUser()))
+                    .collect(Collectors.toList());
         }
     }
 
@@ -190,6 +195,19 @@ public class DetailResponseDto {
             } else {
                 this.children = new ArrayList<>();
             }
+        }
+    }
+
+    @Getter
+    public static class DetailTeamMemberDto{
+        private Long userId;
+        private String nickname;
+        private String profile;
+
+        public DetailTeamMemberDto(User user){
+            this.userId = user.getUserId();
+            this.nickname = user.getNickname();
+            this.profile = user.getProfile();
         }
     }
 }

--- a/src/main/java/org/example/weneedbe/domain/article/dto/response/DetailResponseDto.java
+++ b/src/main/java/org/example/weneedbe/domain/article/dto/response/DetailResponseDto.java
@@ -28,11 +28,11 @@ public class DetailResponseDto {
         private List<CommentResponseDto> comments;
 
 
-        public DetailPortfolioDto(Article article, User user, int heartCount, int bookmarkCount, List<Article> userPortfolio
-                , boolean isHearted, boolean isBookmarked, List<CommentResponseDto> commentList) {
+        public DetailPortfolioDto(Article article, User user, int heartCount, int bookmarkCount, List<WorkPortfolioArticleDto> workList,
+                                  boolean isHearted, boolean isBookmarked, List<CommentResponseDto> commentList) {
             this.user = new DetailUserDto(user, user.getUserId().equals(article.getUser().getUserId()), isHearted, isBookmarked);
             this.portfolio = new DetailArticleDto(article, heartCount, bookmarkCount);
-            this.workList = initializeWorkList(userPortfolio, article);
+            this.workList = workList;
             this.comments = commentList;
         }
     }
@@ -134,24 +134,14 @@ public class DetailResponseDto {
         private Long articleId;
         private String thumbnail;
         private String title;
-        //북마크여부추가
+        private boolean bookmarked;
 
-        public WorkPortfolioArticleDto(Article article) {
+        public WorkPortfolioArticleDto(Article article, boolean bookmarked) {
             this.articleId = article.getArticleId();
             this.thumbnail = article.getThumbnail();
             this.title = article.getTitle();
+            this.bookmarked = bookmarked;
         }
-    }
-
-    private static List<WorkPortfolioArticleDto> initializeWorkList(List<Article> userPortfolio, Article article) {
-        List<WorkPortfolioArticleDto> workList = new ArrayList<>();
-        for (Article portfolio : userPortfolio) {
-            /* 상세조회하는 게시물 제외하고 workList에 추가 */
-            if (!portfolio.getArticleId().equals(article.getArticleId())) {
-                workList.add(new WorkPortfolioArticleDto(portfolio));
-            }
-        }
-        return workList;
     }
 
     @Getter

--- a/src/main/java/org/example/weneedbe/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/org/example/weneedbe/domain/article/repository/ArticleRepository.java
@@ -1,6 +1,7 @@
 package org.example.weneedbe.domain.article.repository;
 
 import org.example.weneedbe.domain.article.domain.Article;
+import org.example.weneedbe.domain.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -49,6 +50,6 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
             nativeQuery = true)
     Page<Article> findRecruitingByDetailTagsInOrderByCreatedAtDesc(@Param("detailTags") String[] detailTags, Pageable pageable);
 
-    @Query("SELECT ar FROM Article ar WHERE ar.user.userId = :userId AND ar.articleType = 'PORTFOLIO'")
-    List<Article> findPortfolioArticlesByUserId(@Param("userId") Long userId);
+    @Query("SELECT ar FROM Article ar WHERE ar.user = :user AND ar.articleType = 'PORTFOLIO'")
+    List<Article> findPortfolioArticlesByUser(@Param("user") User user);
 }

--- a/src/main/java/org/example/weneedbe/domain/comment/domain/Comment.java
+++ b/src/main/java/org/example/weneedbe/domain/comment/domain/Comment.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 import org.example.weneedbe.domain.article.domain.Article;
 import org.example.weneedbe.domain.comment.dto.request.AddCommentRequest;
 import org.example.weneedbe.domain.user.domain.User;
+import org.example.weneedbe.global.shared.entity.BaseTimeEntity;
 
 @Entity
 @Getter
@@ -19,7 +20,7 @@ import org.example.weneedbe.domain.user.domain.User;
 @NoArgsConstructor
 @Builder
 @Table(name="comment")
-public class Comment {
+public class Comment extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
게시물 상세조회시 댓글유저의 정보 및 북마크여부 데이터를 추가로 반환합니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
![image](https://github.com/Leets-Official/WeNeed-BE/assets/108799865/0c39904f-532a-473f-b22c-751aed195260)


<br>

## 4. 완료 사항
- [x] 포트폴리오 - comments :  댓글 쓴 유저의 userId, nickname, major, grade, createdAt, profile 추가
- [x] 포트폴리오 - worklist : 각 게시물마다 “나” 유저가 북마크 했는지 여부 추가
- [x] 포트폴리오 - teamMembers (userId, nickname, profile) 추가
- [x] 리크루팅- comments :  댓글 쓴 유저의 userId, nickname, major, grade, createdAt, profile 추가

<br>

## 5. 추가 사항
close #47 
