### PR TITLE
[feat] #51 마이페이지 my output 조회 api 구현

### DIFF
--- a/src/main/java/org/example/weneedbe/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/org/example/weneedbe/domain/article/repository/ArticleRepository.java
@@ -1,8 +1,6 @@
 package org.example.weneedbe.domain.article.repository;
 
 import org.example.weneedbe.domain.article.domain.Article;
-import org.example.weneedbe.domain.article.domain.Type;
-import org.example.weneedbe.domain.bookmark.domain.Bookmark;
 import org.example.weneedbe.domain.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/org/example/weneedbe/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/org/example/weneedbe/domain/article/repository/ArticleRepository.java
@@ -1,6 +1,8 @@
 package org.example.weneedbe.domain.article.repository;
 
 import org.example.weneedbe.domain.article.domain.Article;
+import org.example.weneedbe.domain.article.domain.Type;
+import org.example.weneedbe.domain.bookmark.domain.Bookmark;
 import org.example.weneedbe.domain.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
+++ b/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
@@ -73,8 +73,9 @@ public class MyPageController {
             @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<MyPageArticleInfoResponse> getMyOutputInfo(
-            @RequestHeader("Authorizaion") String authorizationHeader) {
+    @GetMapping("/find-my-output")
+    public ResponseEntity<List<MyPageArticleInfoResponse>> getMyOutputInfo(
+            @RequestHeader("Authorization") String authorizationHeader) {
         return ResponseEntity.ok(userService.getMyOutputInfo(authorizationHeader));
     }
 }

--- a/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
+++ b/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
@@ -65,4 +65,16 @@ public class MyPageController {
         @RequestHeader("Authorization") String authorizationHeader) {
         return ResponseEntity.ok(userService.getInterestingCrewInfo(authorizationHeader));
     }
+
+    @Operation(summary = "마이페이지의 마이 아웃풋 조회", description = "사용자가 작성한 포트폴리오 게시물을 가져옵니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<MyPageArticleInfoResponse> getMyOutputInfo(
+            @RequestHeader("Authorizaion") String authorizationHeader) {
+        return ResponseEntity.ok(userService.getMyOutputInfo(authorizationHeader));
+    }
 }

--- a/src/main/java/org/example/weneedbe/domain/user/dto/response/mypage/MyPageArticleInfoResponse.java
+++ b/src/main/java/org/example/weneedbe/domain/user/dto/response/mypage/MyPageArticleInfoResponse.java
@@ -3,6 +3,8 @@ package org.example.weneedbe.domain.user.dto.response.mypage;
 import lombok.Getter;
 import org.example.weneedbe.domain.article.domain.Article;
 
+import java.util.List;
+
 @Getter
 public class MyPageArticleInfoResponse {
 
@@ -11,12 +13,14 @@ public class MyPageArticleInfoResponse {
   private String title;
   private int viewCount;
   private int heartCount;
+  private List<String> teamProfiles;
 
-  public MyPageArticleInfoResponse(Article article, int heartCount) {
+  public MyPageArticleInfoResponse(Article article, int heartCount, List<String> teamProfiles) {
     this.articleId = article.getArticleId();
     this.thumbnail = article.getThumbnail();
     this.title = article.getTitle();
     this.viewCount = article.getViewCount();
     this.heartCount = heartCount;
+    this.teamProfiles = teamProfiles;
   }
 }

--- a/src/main/java/org/example/weneedbe/domain/user/repository/UserArticleRepository.java
+++ b/src/main/java/org/example/weneedbe/domain/user/repository/UserArticleRepository.java
@@ -4,11 +4,11 @@ import org.example.weneedbe.domain.article.domain.Type;
 import org.example.weneedbe.domain.user.domain.User;
 import org.example.weneedbe.domain.user.domain.UserArticle;
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 
 public interface UserArticleRepository extends JpaRepository<UserArticle, Long> {
 
     List<UserArticle> findAllByUserAndArticle_ArticleTypeOrderByArticle_CreatedAtDesc(User user, Type articleType);
 
+    List<UserArticle> findAllByArticle_ArticleId(Long articleId);
 }

--- a/src/main/java/org/example/weneedbe/domain/user/repository/UserArticleRepository.java
+++ b/src/main/java/org/example/weneedbe/domain/user/repository/UserArticleRepository.java
@@ -1,0 +1,2 @@
+package org.example.weneedbe.domain.user.repository;public interface UserArticleRepository {
+}

--- a/src/main/java/org/example/weneedbe/domain/user/repository/UserArticleRepository.java
+++ b/src/main/java/org/example/weneedbe/domain/user/repository/UserArticleRepository.java
@@ -1,2 +1,14 @@
-package org.example.weneedbe.domain.user.repository;public interface UserArticleRepository {
+package org.example.weneedbe.domain.user.repository;
+
+import org.example.weneedbe.domain.article.domain.Type;
+import org.example.weneedbe.domain.user.domain.User;
+import org.example.weneedbe.domain.user.domain.UserArticle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserArticleRepository extends JpaRepository<UserArticle, Long> {
+
+    List<UserArticle> findAllByUserAndArticle_ArticleTypeOrderByArticle_CreatedAtDesc(User user, Type articleType);
+
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 마이페이지 내 사용자가 작성한 포트폴리오 게시글을 조회하기 위함입니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.

### 팀원 프로필 추가 로직 수정 전
<img width="1059" alt="스크린샷 2024-01-24 오전 1 39 49" src="https://github.com/Leets-Official/WeNeed-BE/assets/129377887/17810249-3b7b-4f6e-a0b0-e06be95c6eac">

### 팀원 프로필 추가 로직 수정 후
<img width="986" alt="스크린샷 2024-01-24 오후 5 53 13" src="https://github.com/Leets-Official/WeNeed-BE/assets/129377887/3d10de5d-6ffd-4beb-9b2d-ceb5eab6133a">


<br>

## 4. 완료 사항
- 로그인한 사용자가 작성한 포트폴리오 게시글 목록을 가져오는 api 
- 관심 크루 조회와 마찬가지로 최신순으로 가져오도록 하였습니다.
close #45 
<br>

## 5. 추가 사항
- 게시글 내 속한 팀원들의 프로필을 가져오는 로직을 추가하였습니다.