### PR TITLE
[feat] #59 게시물 삭제 api 구현

### DIFF
--- a/src/main/java/org/example/weneedbe/domain/article/api/ArticleController.java
+++ b/src/main/java/org/example/weneedbe/domain/article/api/ArticleController.java
@@ -142,4 +142,18 @@ public class ArticleController {
         articleService.editPortfolio(authorizationHeader, articleId, thumbnail, images, files, request);
         return ResponseEntity.ok("포트폴리오 게시물이 수정되었습니다");
     }
+
+    @Operation(summary = "게시물 삭제", description = "게시물을 삭제합니다")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @DeleteMapping("{articleId}")
+    public ResponseEntity<String> deleteArticle(
+            @RequestHeader("Authorization") String authorizationHeader, @PathVariable Long articleId){
+        articleService.deleteArticle(authorizationHeader, articleId);
+        return ResponseEntity.ok("게시물이 삭제되었습니다.");
+    }
 }

--- a/src/main/java/org/example/weneedbe/domain/article/api/MainController.java
+++ b/src/main/java/org/example/weneedbe/domain/article/api/MainController.java
@@ -30,7 +30,7 @@ public class MainController {
     })
     @GetMapping("/portfolio")
     ResponseEntity<MainPortfolioDto> getMainPagePortfolio(
-            @RequestParam int size, @RequestParam int page, @RequestParam String sort, @RequestParam(required = false, defaultValue = "") String[] detailTags,
+            @RequestParam int size, @RequestParam int page, @RequestParam(defaultValue = "DESC") String sort, @RequestParam(required = false, defaultValue = "") String[] detailTags,
             @RequestHeader(name = "Authorization", required = false)  String authorizationHeader) {
         return ResponseEntity.ok(mainService.getPortfolioArticleList(size, page, sort, detailTags, authorizationHeader));
     }

--- a/src/main/java/org/example/weneedbe/domain/article/application/ArticleService.java
+++ b/src/main/java/org/example/weneedbe/domain/article/application/ArticleService.java
@@ -123,9 +123,8 @@ public class ArticleService {
     }
 
     public DetailPortfolioDto getDetailPortfolio(String authorizationHeader, Long articleId) {
-        Long userId = getUserIdFromAuthorizationHeader(authorizationHeader);
-        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
-        Article article = articleRepository.findById(articleId).orElseThrow(ArticleNotFoundException::new);
+        User user = findUser(authorizationHeader);
+        Article article = findArticle(articleId);
 
         article.plusViewCount(article.getViewCount() + 1);
         articleRepository.save(article);
@@ -156,16 +155,9 @@ public class ArticleService {
         return workList;
     }
 
-    private Long getUserIdFromAuthorizationHeader(String authorizationHeader) {
-        String token = tokenProvider.getTokenFromAuthorizationHeader(authorizationHeader);
-        Long userIdFromToken = tokenProvider.getUserIdFromToken(token);
-        return userIdFromToken;
-    }
-
     public DetailRecruitDto getDetailRecruit(String authorizationHeader, Long articleId) {
-        Long userId = getUserIdFromAuthorizationHeader(authorizationHeader);
-        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
-        Article article = articleRepository.findById(articleId).orElseThrow(ArticleNotFoundException::new);
+        User user = findUser(authorizationHeader);
+        Article article = findArticle(articleId);
 
         article.plusViewCount(article.getViewCount() + 1);
         articleRepository.save(article);
@@ -193,15 +185,10 @@ public class ArticleService {
     public void editPortfolio(String authorizationHeader, Long articleId, MultipartFile thumbnail,
         List<MultipartFile> images, List<MultipartFile> files, ArticleRequest request)
         throws IOException {
+        User user = findUser(authorizationHeader);
+        Article article = findArticle(articleId);
 
-        Long userId = getUserIdFromAuthorizationHeader(authorizationHeader);
-        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
-        Article article = articleRepository.findById(articleId)
-            .orElseThrow(ArticleNotFoundException::new);
-
-        if (!user.equals(article.getUser())) {
-            throw new AuthorMismatchException();
-        }
+        validateUserOwnership(article, user);
 
         /* 기존 데이터 삭제 */
         userArticleRepository.deleteAllByArticle_ArticleId(articleId);
@@ -232,5 +219,30 @@ public class ArticleService {
             );
         }
         return userArticles;
+    }
+    public void deleteArticle(String authorizationHeader, Long articleId){
+        User user = findUser(authorizationHeader);
+        Article article = findArticle(articleId);
+
+        validateUserOwnership(article, user);
+
+        articleRepository.delete(article);
+    }
+
+    private User findUser(String authorizationHeader){
+        String token = tokenProvider.getTokenFromAuthorizationHeader(authorizationHeader);
+        Long userId = tokenProvider.getUserIdFromToken(token);
+        return userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+    }
+
+    private Article findArticle(Long articleId){
+        return articleRepository.findById(articleId)
+                .orElseThrow(ArticleNotFoundException::new);
+    }
+
+    private void validateUserOwnership(Article article, User user){
+        if (!user.equals(article.getUser())) {
+            throw new AuthorMismatchException();
+        }
     }
 }

--- a/src/main/java/org/example/weneedbe/domain/article/domain/Article.java
+++ b/src/main/java/org/example/weneedbe/domain/article/domain/Article.java
@@ -12,6 +12,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.example.weneedbe.domain.article.dto.request.ArticleRequest;
+import org.example.weneedbe.domain.bookmark.domain.Bookmark;
 import org.example.weneedbe.domain.comment.domain.Comment;
 import org.example.weneedbe.domain.file.domain.File;
 import org.example.weneedbe.domain.user.domain.User;
@@ -77,6 +78,12 @@ public class Article extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> commentList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ArticleLike> likeList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Bookmark> bookmarkList = new ArrayList<>();
 
     public static Article of(String thumbnail, List<String> images, List<String> files,
         ArticleRequest request, User user) {


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

**추가작업**
- [x] 메인페이지 - 포트폴리오 sort default값 “DESC”로 설정 추가

**게시물삭제**
- [x] articleId에 해당하는 article을 삭제합니다
- [x] article의 bookmark, like, file, comment, content_data, detail_skills, detail_tags, user_article 전부 삭제합니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
articleId - 3 게시물 삭제
![image](https://github.com/Leets-Official/WeNeed-BE/assets/108799865/4350a5d5-945e-4997-9b19-60b630979503)

<br>

## 4. 완료 사항


<br>

## 5. 추가 사항
close #59 
