### PR TITLE
[feat] #62 액세스 토큰 재발급 api

### DIFF
--- a/src/main/java/org/example/weneedbe/domain/oauth/api/OAuthController.java
+++ b/src/main/java/org/example/weneedbe/domain/oauth/api/OAuthController.java
@@ -22,7 +22,7 @@ public class OAuthController {
     public LoginResponse get(@RequestParam("code") String code) throws GeneralSecurityException, IOException {
         User user = oAuthService.getGoogleToken(code);
         String accessToken = this.tokenProvider.generateAccessToken(user);
-        String refreshToken = this.tokenProvider.generateRefreshToken(user);
+        String refreshToken = this.tokenProvider.returnRefreshToken(user);
 
         return new LoginResponse(accessToken, refreshToken);
     }

--- a/src/main/java/org/example/weneedbe/domain/token/api/TokenController.java
+++ b/src/main/java/org/example/weneedbe/domain/token/api/TokenController.java
@@ -1,0 +1,38 @@
+package org.example.weneedbe.domain.token.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.example.weneedbe.domain.token.dto.request.TokenRequest;
+import org.example.weneedbe.domain.token.dto.response.TokenResponse;
+import org.example.weneedbe.global.error.ErrorResponse;
+import org.example.weneedbe.global.jwt.TokenProvider;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Token Controller", description = "토큰 재발급 관련 API입니다.")
+@RestController
+@RequiredArgsConstructor
+public class TokenController {
+    private final TokenProvider tokenProvider;
+
+    @Operation(summary = "액세스 토큰 재발급", description = "리프레시 토큰을 대조하여 액세스 및 리프레시 토큰을 재발급합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @Transactional
+    @PostMapping("/regenerate-token")
+    public ResponseEntity<TokenResponse> regenerateToken(@RequestBody TokenRequest request) {
+        return ResponseEntity.ok(tokenProvider.regenerateToken(request.getRefreshToken()));
+    }
+}

--- a/src/main/java/org/example/weneedbe/domain/token/api/TokenController.java
+++ b/src/main/java/org/example/weneedbe/domain/token/api/TokenController.java
@@ -12,7 +12,6 @@ import org.example.weneedbe.domain.token.dto.response.TokenResponse;
 import org.example.weneedbe.global.error.ErrorResponse;
 import org.example.weneedbe.global.jwt.TokenProvider;
 import org.springframework.http.ResponseEntity;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,8 +29,7 @@ public class TokenController {
             @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @Transactional
-    @PostMapping("/regenerate-token")
+    @PostMapping("/refresh")
     public ResponseEntity<TokenResponse> regenerateToken(@RequestBody TokenRequest request) {
         return ResponseEntity.ok(tokenProvider.regenerateToken(request.getRefreshToken()));
     }

--- a/src/main/java/org/example/weneedbe/domain/token/dto/request/TokenRequest.java
+++ b/src/main/java/org/example/weneedbe/domain/token/dto/request/TokenRequest.java
@@ -2,8 +2,10 @@ package org.example.weneedbe.domain.token.dto.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class TokenRequest {
     private String refreshToken;

--- a/src/main/java/org/example/weneedbe/domain/token/dto/request/TokenRequest.java
+++ b/src/main/java/org/example/weneedbe/domain/token/dto/request/TokenRequest.java
@@ -1,0 +1,10 @@
+package org.example.weneedbe.domain.token.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenRequest {
+    private String refreshToken;
+}

--- a/src/main/java/org/example/weneedbe/domain/token/dto/response/TokenResponse.java
+++ b/src/main/java/org/example/weneedbe/domain/token/dto/response/TokenResponse.java
@@ -1,0 +1,13 @@
+package org.example.weneedbe.domain.token.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class TokenResponse {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/org/example/weneedbe/domain/user/api/UnivCertController.java
+++ b/src/main/java/org/example/weneedbe/domain/user/api/UnivCertController.java
@@ -7,27 +7,22 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
+import org.example.weneedbe.domain.user.dto.request.CertifyCodeRequest;
 import org.example.weneedbe.global.error.ErrorResponse;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 
 @Tag(name = "Mail Certification Controller", description = "메일 인증 관련 API입니다.")
 @RestController
 @RequestMapping("/api/v1")
-@Transactional
 @Slf4j
 public class UnivCertController {
     private final static String UNIV_NAME = "가천대학교";
     @Value("${univcertKey}")
     private String apiKey;
-    private String email;
 
     @Operation(summary = "학교 메일 조회", description = "입력한 이메일이 가천대학교 소속 이메일인지 확인합니다.")
     @ApiResponses({
@@ -38,8 +33,7 @@ public class UnivCertController {
     })
     @PostMapping("/certify")
     public void checkMailWithUniv(@RequestParam String email) throws IOException {
-        this.email = email;
-        log.info("\nemail:{}", this.email);
+        log.info("\nemail:{}", email);
         UnivCert.certify(apiKey, email, UNIV_NAME, true);
     }
 
@@ -51,7 +45,7 @@ public class UnivCertController {
             @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PostMapping("/certifycode")
-    public void checkVerificationCode(@RequestParam int code) throws IOException {
-        UnivCert.certifyCode(apiKey, email, UNIV_NAME, code);
+    public void checkVerificationCode(@RequestBody CertifyCodeRequest request) throws IOException {
+        UnivCert.certifyCode(apiKey, request.getEmail(), UNIV_NAME, request.getCode());
     }
 }

--- a/src/main/java/org/example/weneedbe/domain/user/api/UserInfoController.java
+++ b/src/main/java/org/example/weneedbe/domain/user/api/UserInfoController.java
@@ -43,7 +43,8 @@ public class UserInfoController {
             @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PostMapping("/info")
-    public ResponseEntity<UserInfoResponse> setUserInfo(@RequestBody UserInfoRequest request) throws Exception {
-        return userService.setUserInfo(request);
+    public ResponseEntity<UserInfoResponse> setUserInfo(@RequestBody UserInfoRequest request,
+                                                        @RequestHeader("Authorization") String authorizationHeader) throws Exception {
+        return userService.setUserInfo(request, authorizationHeader);
     }
 }

--- a/src/main/java/org/example/weneedbe/domain/user/dto/request/CertifyCodeRequest.java
+++ b/src/main/java/org/example/weneedbe/domain/user/dto/request/CertifyCodeRequest.java
@@ -1,0 +1,11 @@
+package org.example.weneedbe.domain.user.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CertifyCodeRequest {
+    private int code;
+    private String email;
+}

--- a/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
+++ b/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
@@ -54,19 +54,18 @@ public class UserService {
                 .orElseThrow(IllegalArgumentException::new);
     }
 
-    public ResponseEntity<UserInfoResponse> setUserInfo(UserInfoRequest request) throws Exception {
+    public ResponseEntity<UserInfoResponse> setUserInfo(UserInfoRequest request, String authorizationHeader) throws Exception {
+        Long userId = getUserIdFromHeader(authorizationHeader);
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         try {
-            /* 토큰을 통한 user 객체를 불러옴 */
-            /* 아직 토큰이 없기 때문에 임시 객체를 사용 */
-            User mockUser = userRepository.findById(1L).orElseThrow();
-            mockUser.setUserInfo(request.getMajor(),
+            user.setUserInfo(request.getMajor(),
                     request.getDoubleMajor(),
                     request.getNickname(),
                     request.getUserGrade(),
                     request.getInterestField(),
                     true);
 
-            userRepository.save(mockUser);
+            userRepository.save(user);
         } catch (Exception e) {
             log.info(e.getMessage());
             throw e;

--- a/src/main/java/org/example/weneedbe/global/error/ErrorCode.java
+++ b/src/main/java/org/example/weneedbe/global/error/ErrorCode.java
@@ -18,7 +18,8 @@ public enum ErrorCode {
     INVALID_INPUT_VALUE(400, "INVALID_INPUT_VALUE", "유효하지 않은 입력값입니다."),
     INVALID_EDIT_VALUE(400, "INVALID_EDIT_VALUE", "유효하지 않은 변경값입니다."),
     USER_NOT_REGISTERED(400, "USER_NOT_REGISTERED","회원가입이 완료되지 않은 유저입니다."),
-    AUTHOR_MISMATCH_ERROR(400, "AUTHOR_MISMATCH_ERROR", "작성자와 사용자가 일치하지 않습니다.");
+    AUTHOR_MISMATCH_ERROR(400, "AUTHOR_MISMATCH_ERROR", "작성자와 사용자가 일치하지 않습니다."),
+    TOKEN_NOT_FOUND(400, "TOKEN_NOT_FOUND", "해당 유저의 리프레시 토큰을 찾을 수 없습니다.");
 
     private final int httpStatus;
     private final String code;

--- a/src/main/java/org/example/weneedbe/global/jwt/TokenProvider.java
+++ b/src/main/java/org/example/weneedbe/global/jwt/TokenProvider.java
@@ -2,9 +2,10 @@ package org.example.weneedbe.global.jwt;
 
 import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
-import org.example.weneedbe.domain.token.domain.RefreshToken;
-import org.example.weneedbe.domain.token.repository.RefreshTokenRepository;
+import org.example.weneedbe.domain.token.dto.response.TokenResponse;
 import org.example.weneedbe.domain.user.domain.User;
+import org.example.weneedbe.domain.user.exception.UserNotFoundException;
+import org.example.weneedbe.domain.user.repository.UserRepository;
 import org.example.weneedbe.global.jwt.exception.ExpiredTokenException;
 import org.example.weneedbe.global.jwt.exception.InvalidInputValueException;
 import org.example.weneedbe.global.jwt.exception.InvalidTokenException;
@@ -17,7 +18,6 @@ import org.springframework.stereotype.Service;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Date;
-import java.util.Optional;
 import java.util.Set;
 
 @RequiredArgsConstructor
@@ -27,20 +27,24 @@ public class TokenProvider {
     public static final Duration ACCESS_TOKEN_DURATION = Duration.ofDays(1);
 
     private final JwtProperties jwtProperties;
-    private final RefreshTokenRepository refreshTokenRepository;
     private final RefreshTokenService refreshTokenService;
+    private final UserRepository userRepository;
 
     public String generateAccessToken(User user) {
         return makeToken(ACCESS_TOKEN_DURATION, user);
     }
-
     public String generateRefreshToken(User user) {
+        return makeToken(REFRESH_TOKEN_DURATION, user);
+    }
+
+    public String returnRefreshToken(User user) {
+        String newRefreshToken = generateRefreshToken(user);
+        return refreshTokenService.returnRefreshToken(user.getUserId(), newRefreshToken);
+    }
+
+    public String generateNewRefreshToken(User user) {
         String newRefreshToken = makeToken(REFRESH_TOKEN_DURATION, user);
-        Optional<RefreshToken> refreshToken = refreshTokenRepository.findByUserId(user.getUserId());
-        if (refreshToken.isEmpty()) {
-            refreshTokenService.saveRefreshToken(user.getUserId(), newRefreshToken);
-        }
-        return newRefreshToken;
+        return refreshTokenService.generateNewRefreshToken(user.getUserId(), newRefreshToken);
     }
 
     private String makeToken(Duration duration, User user) {
@@ -102,5 +106,16 @@ public class TokenProvider {
             throw new InvalidInputValueException();
         }
         return authorizationHeader.substring(7);
+    }
+
+    public TokenResponse regenerateToken(String refreshToken) {
+        validToken(refreshToken);
+        Long userId = getUserIdFromToken(refreshToken);
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+
+        return TokenResponse.builder()
+                .accessToken(generateAccessToken(user))
+                .refreshToken(generateNewRefreshToken(user))
+                .build();
     }
 }

--- a/src/main/java/org/example/weneedbe/global/jwt/exception/TokenNotFoundException.java
+++ b/src/main/java/org/example/weneedbe/global/jwt/exception/TokenNotFoundException.java
@@ -1,0 +1,10 @@
+package org.example.weneedbe.global.jwt.exception;
+
+import org.example.weneedbe.global.error.ErrorCode;
+import org.example.weneedbe.global.error.exception.ServiceException;
+
+public class TokenNotFoundException extends ServiceException {
+    public TokenNotFoundException() {
+        super(ErrorCode.TOKEN_NOT_FOUND);
+    }
+}

--- a/src/main/java/org/example/weneedbe/global/jwt/service/RefreshTokenService.java
+++ b/src/main/java/org/example/weneedbe/global/jwt/service/RefreshTokenService.java
@@ -30,13 +30,4 @@ public class RefreshTokenService {
         refreshTokenRepository.save(initialRefreshToken);
         return newRefreshToken;
     }
-
-    public String generateNewRefreshToken(Long userId, String newRefreshToken) {
-        Optional<RefreshToken> optionalRefreshToken = refreshTokenRepository.findByUserId(userId);
-
-        RefreshToken existingRefreshToken = optionalRefreshToken.get();
-
-        refreshTokenRepository.save(existingRefreshToken.update(newRefreshToken));
-        return newRefreshToken;
-    }
 }

--- a/src/main/java/org/example/weneedbe/global/jwt/service/RefreshTokenService.java
+++ b/src/main/java/org/example/weneedbe/global/jwt/service/RefreshTokenService.java
@@ -18,15 +18,25 @@ public class RefreshTokenService {
                 .orElseThrow(InvalidTokenException::new);
     }
 
-    public void saveRefreshToken(Long userId, String newRefreshToken) {
-        Optional<RefreshToken> optionalRefreshToken = refreshTokenRepository.findByUserId(userId);
+    public String returnRefreshToken(Long userId, String newRefreshToken) {
+        Optional<RefreshToken> optionalRefreshToken = refreshTokenRepository.findByUserId(userId); //유저의 refreshToken 보유 여부를 확인한다.
 
-        if (optionalRefreshToken.isPresent()) {
+        if (optionalRefreshToken.isPresent()) { // 최초 로그인이 아닐 시
             RefreshToken existingRefreshToken = optionalRefreshToken.get();
-            existingRefreshToken.update(newRefreshToken);
-            return;
+            return existingRefreshToken.getRefreshToken();
         }
+        //최초 로그인 시
         RefreshToken initialRefreshToken = new RefreshToken(userId, newRefreshToken);
         refreshTokenRepository.save(initialRefreshToken);
+        return newRefreshToken;
+    }
+
+    public String generateNewRefreshToken(Long userId, String newRefreshToken) {
+        Optional<RefreshToken> optionalRefreshToken = refreshTokenRepository.findByUserId(userId);
+
+        RefreshToken existingRefreshToken = optionalRefreshToken.get();
+
+        refreshTokenRepository.save(existingRefreshToken.update(newRefreshToken));
+        return newRefreshToken;
     }
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 액세스 토큰 만료시 재발급받기 위함입니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
- 로그인시마다 로직 상의 오류로 리프레시 토큰이 계속해서 재발급되는 오류를 발견하여 수정하였습니다.
<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="1421" alt="스크린샷 2024-01-25 오후 9 20 31" src="https://github.com/Leets-Official/WeNeed-BE/assets/129377887/6bd010cd-c9d4-449a-b91a-b3e0344d0bda">

<br>

## 4. 완료 사항
- 액세스 토큰 재발급 api
- 리프레시 토큰 무한 재발급 오류 수정
- close #56 
<br>

## 5. 추가 사항
