### PR TITLE
[feat] #65 타인 마이페이지 조회 api

### DIFF
--- a/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
+++ b/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
@@ -36,9 +36,9 @@ public class MyPageController {
         @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @GetMapping("/basic-info")
+    @GetMapping("/basic-info/{userId}")
     public ResponseEntity<BasicInfoResponse> getInfo(@RequestHeader("Authorization") String authorizationHeader,
-                                                     @RequestParam Long userId) {
+                                                     @PathVariable Long userId) {
         return ResponseEntity.ok(userService.getBasicInfo(authorizationHeader, userId, Type.PORTFOLIO));
     }
 

--- a/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
+++ b/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
@@ -39,7 +39,7 @@ public class MyPageController {
     @GetMapping("/basic-info")
     public ResponseEntity<BasicInfoResponse> getInfo(@RequestHeader("Authorization") String authorizationHeader,
                                                      @RequestParam Long userId) {
-        return ResponseEntity.ok(userService.getBasicInfo(authorizationHeader, userId));
+        return ResponseEntity.ok(userService.getBasicInfo(authorizationHeader, userId, Type.PORTFOLIO));
     }
 
     @Operation(summary = "마이페이지 내 프로필 수정", description = "현재 로그인한 사용자의 프로필 정보를 수정합니다.")
@@ -80,19 +80,6 @@ public class MyPageController {
     public ResponseEntity<List<MyPageArticleInfoResponse>> getInterestingPortfolioInfo(
             @RequestHeader("Authorization") String authorizationHeader) {
         return ResponseEntity.ok(userService.getBookmarkInfo(authorizationHeader, Type.PORTFOLIO));
-    }
-
-    @Operation(summary = "마이페이지의 마이 아웃풋 조회", description = "사용자가 작성한 포트폴리오 게시물을 가져옵니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    @GetMapping("/my-outputs")
-    public ResponseEntity<List<MyPageArticleInfoResponse>> getMyOutputInfo(
-            @RequestHeader("Authorization") String authorizationHeader) {
-        return ResponseEntity.ok(userService.getArticleInfo(authorizationHeader, Type.PORTFOLIO));
     }
 
     @Operation(summary = "마이페이지의 마이 크루 조회", description = "사용자가 작성한 리크루팅 게시물을 가져옵니다.")

--- a/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
+++ b/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
@@ -11,8 +11,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.example.weneedbe.domain.article.domain.Type;
 import org.example.weneedbe.domain.user.dto.request.EditMyInfoRequest;
+import org.example.weneedbe.domain.user.dto.response.mypage.BasicInfoResponse;
 import org.example.weneedbe.domain.user.dto.response.mypage.EditMyInfoResponse;
-import org.example.weneedbe.domain.user.dto.response.mypage.GetMyInfoResponse;
 import org.example.weneedbe.domain.user.dto.response.mypage.MyPageArticleInfoResponse;
 import org.example.weneedbe.domain.user.service.UserService;
 import org.example.weneedbe.global.error.ErrorResponse;
@@ -28,16 +28,18 @@ public class MyPageController {
 
     private final UserService userService;
 
-    @Operation(summary = "마이페이지의 내 정보", description = "현재 로그인한 사용자의 정보를 마이페이지 내 불러옵니다.")
+    @Operation(summary = "마이페이지의 사용자 정보 및 Output 정보",
+            description = "헤더와 userId를 비교해 상황에 맞는 사용자 정보 및 작성한 포트폴리오 정보를 조회합니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "200"),
         @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @GetMapping("/my-info")
-    public ResponseEntity<GetMyInfoResponse> getInfo(@RequestHeader("Authorization") String authorizationHeader) throws IOException {
-        return ResponseEntity.ok(userService.getInfo(authorizationHeader));
+    @GetMapping("/basic-info")
+    public ResponseEntity<BasicInfoResponse> getInfo(@RequestHeader("Authorization") String authorizationHeader,
+                                                     @RequestParam Long userId) {
+        return ResponseEntity.ok(userService.getBasicInfo(authorizationHeader, userId));
     }
 
     @Operation(summary = "마이페이지 내 프로필 수정", description = "현재 로그인한 사용자의 프로필 정보를 수정합니다.")
@@ -104,29 +106,5 @@ public class MyPageController {
     public ResponseEntity<List<MyPageArticleInfoResponse>> getMyCrewInfo(
             @RequestHeader("Authorization") String authorizationHeader) {
         return ResponseEntity.ok(userService.getArticleInfo(authorizationHeader, Type.RECRUITING));
-    }
-
-    @Operation(summary = "다른 사용자의 마이페이지 내 세부정보 조회", description = "userId를 통한 다른 사용자의 세부 정보를 조회합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    @GetMapping("/{userId}/info")
-    public ResponseEntity<GetMyInfoResponse> getInfoFromUserId(@PathVariable Long userId) {
-        return ResponseEntity.ok(userService.getInfoFromUserId(userId));
-    }
-
-    @Operation(summary = "다른 사용자의 마이페이지 내 아웃풋 조회", description = "userId를 통한 다른 사용자가 작성한 포트폴리오 게시물을 조회합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    @GetMapping("/{userId}/outputs")
-    public ResponseEntity<List<MyPageArticleInfoResponse>> getOutputFromUserId(@PathVariable Long userId) {
-        return ResponseEntity.ok(userService.getOutputFromUserId(userId, Type.PORTFOLIO));
     }
 }

--- a/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
+++ b/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
@@ -106,7 +106,7 @@ public class MyPageController {
         return ResponseEntity.ok(userService.getMyInfo(authorizationHeader, Type.RECRUITING));
     }
 
-    @Operation(summary = "다른 사용자의 정보를 조회", description = "다른 사용자의 세부 정보를 조회합니다.")
+    @Operation(summary = "다른 사용자의 세부 정보 조회", description = "userId를 통한 다른 사용자의 세부 정보를 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200"),
             @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
@@ -114,8 +114,19 @@ public class MyPageController {
             @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping("/{userId}/info")
-    public ResponseEntity<GetMyInfoResponse> getMyInfoFromUserId(@RequestHeader("Authorization") String authorizationHeader,
-                                                     @PathVariable Long userId) {
+    public ResponseEntity<GetMyInfoResponse> getMyInfoFromUserId(@PathVariable Long userId) {
         return ResponseEntity.ok(userService.getMyInfoFromUserId(userId));
+    }
+
+    @Operation(summary = "다른 사용자의 아웃풋 조회", description = "userId를 통한 다른 사용자가 작성한 포트폴리오 게시물을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/{userId}/outputs")
+    public ResponseEntity<List<MyPageArticleInfoResponse>> getOutputFromUserId(@PathVariable Long userId) {
+        return ResponseEntity.ok(userService.getOutputFromUserId(userId, Type.PORTFOLIO));
     }
 }

--- a/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
+++ b/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
@@ -106,7 +106,7 @@ public class MyPageController {
         return ResponseEntity.ok(userService.getArticleInfo(authorizationHeader, Type.RECRUITING));
     }
 
-    @Operation(summary = "다른 사용자의 세부 정보 조회", description = "userId를 통한 다른 사용자의 세부 정보를 조회합니다.")
+    @Operation(summary = "다른 사용자의 마이페이지 내 세부정보 조회", description = "userId를 통한 다른 사용자의 세부 정보를 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200"),
             @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
@@ -118,7 +118,7 @@ public class MyPageController {
         return ResponseEntity.ok(userService.getInfoFromUserId(userId));
     }
 
-    @Operation(summary = "다른 사용자의 아웃풋 조회", description = "userId를 통한 다른 사용자가 작성한 포트폴리오 게시물을 조회합니다.")
+    @Operation(summary = "다른 사용자의 마이페이지 내 아웃풋 조회", description = "userId를 통한 다른 사용자가 작성한 포트폴리오 게시물을 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200"),
             @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),

--- a/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
+++ b/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
@@ -36,8 +36,8 @@ public class MyPageController {
         @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping("/my-info")
-    public ResponseEntity<GetMyInfoResponse> getMyInfo(@RequestHeader("Authorization") String authorizationHeader) throws IOException {
-        return ResponseEntity.ok(userService.getMyInfo(authorizationHeader));
+    public ResponseEntity<GetMyInfoResponse> getInfo(@RequestHeader("Authorization") String authorizationHeader) throws IOException {
+        return ResponseEntity.ok(userService.getInfo(authorizationHeader));
     }
 
     @Operation(summary = "마이페이지 내 프로필 수정", description = "현재 로그인한 사용자의 프로필 정보를 수정합니다.")
@@ -48,10 +48,10 @@ public class MyPageController {
         @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PatchMapping("/my-info")
-    public ResponseEntity<EditMyInfoResponse> editMyInfo(@RequestHeader("Authorization") String authorizationHeader,
+    public ResponseEntity<EditMyInfoResponse> editInfo(@RequestHeader("Authorization") String authorizationHeader,
         @RequestPart MultipartFile profileImage,
         @RequestPart EditMyInfoRequest request) throws IOException {
-        return ResponseEntity.ok(userService.editMyInfo(authorizationHeader, profileImage, request));
+        return ResponseEntity.ok(userService.editInfo(authorizationHeader, profileImage, request));
     }
 
     @Operation(summary = "마이페이지의 관심 크루 조회", description = "사용자가 북마크한 팀원모집 게시물을 조회합니다.")
@@ -90,7 +90,7 @@ public class MyPageController {
     @GetMapping("/my-outputs")
     public ResponseEntity<List<MyPageArticleInfoResponse>> getMyOutputInfo(
             @RequestHeader("Authorization") String authorizationHeader) {
-        return ResponseEntity.ok(userService.getMyInfo(authorizationHeader, Type.PORTFOLIO));
+        return ResponseEntity.ok(userService.getArticleInfo(authorizationHeader, Type.PORTFOLIO));
     }
 
     @Operation(summary = "마이페이지의 마이 크루 조회", description = "사용자가 작성한 리크루팅 게시물을 가져옵니다.")
@@ -103,7 +103,7 @@ public class MyPageController {
     @GetMapping("/my-crews")
     public ResponseEntity<List<MyPageArticleInfoResponse>> getMyCrewInfo(
             @RequestHeader("Authorization") String authorizationHeader) {
-        return ResponseEntity.ok(userService.getMyInfo(authorizationHeader, Type.RECRUITING));
+        return ResponseEntity.ok(userService.getArticleInfo(authorizationHeader, Type.RECRUITING));
     }
 
     @Operation(summary = "다른 사용자의 세부 정보 조회", description = "userId를 통한 다른 사용자의 세부 정보를 조회합니다.")
@@ -114,8 +114,8 @@ public class MyPageController {
             @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping("/{userId}/info")
-    public ResponseEntity<GetMyInfoResponse> getMyInfoFromUserId(@PathVariable Long userId) {
-        return ResponseEntity.ok(userService.getMyInfoFromUserId(userId));
+    public ResponseEntity<GetMyInfoResponse> getInfoFromUserId(@PathVariable Long userId) {
+        return ResponseEntity.ok(userService.getInfoFromUserId(userId));
     }
 
     @Operation(summary = "다른 사용자의 아웃풋 조회", description = "userId를 통한 다른 사용자가 작성한 포트폴리오 게시물을 조회합니다.")

--- a/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
+++ b/src/main/java/org/example/weneedbe/domain/user/api/MyPageController.java
@@ -105,4 +105,17 @@ public class MyPageController {
             @RequestHeader("Authorization") String authorizationHeader) {
         return ResponseEntity.ok(userService.getMyInfo(authorizationHeader, Type.RECRUITING));
     }
+
+    @Operation(summary = "다른 사용자의 정보를 조회", description = "다른 사용자의 세부 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/{userId}/info")
+    public ResponseEntity<GetMyInfoResponse> getMyInfoFromUserId(@RequestHeader("Authorization") String authorizationHeader,
+                                                     @PathVariable Long userId) {
+        return ResponseEntity.ok(userService.getMyInfoFromUserId(userId));
+    }
 }

--- a/src/main/java/org/example/weneedbe/domain/user/api/UserInfoController.java
+++ b/src/main/java/org/example/weneedbe/domain/user/api/UserInfoController.java
@@ -45,6 +45,6 @@ public class UserInfoController {
     @PostMapping("/info")
     public ResponseEntity<UserInfoResponse> setUserInfo(@RequestBody UserInfoRequest request,
                                                         @RequestHeader("Authorization") String authorizationHeader) throws Exception {
-        return userService.setUserInfo(request, authorizationHeader);
+        return userService.setInfo(request, authorizationHeader);
     }
 }

--- a/src/main/java/org/example/weneedbe/domain/user/dto/response/mypage/BasicInfoResponse.java
+++ b/src/main/java/org/example/weneedbe/domain/user/dto/response/mypage/BasicInfoResponse.java
@@ -1,2 +1,26 @@
-package org.example.weneedbe.domain.user.dto.response.mypage;public class BasicInfoResponse {
+package org.example.weneedbe.domain.user.dto.response.mypage;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class BasicInfoResponse {
+    private String userNickname;
+    private Boolean sameUser;
+    private GetMyInfoResponse userInfo;
+    private List<MyPageArticleInfoResponse> myOutputList;
+
+    public static BasicInfoResponse from(Boolean sameUser, GetMyInfoResponse userInfo, List<MyPageArticleInfoResponse> myOutputList) {
+        return BasicInfoResponse.builder()
+                .userNickname(userInfo.getNickname())
+                .sameUser(sameUser)
+                .userInfo(userInfo)
+                .myOutputList(myOutputList)
+                .build();
+    }
 }

--- a/src/main/java/org/example/weneedbe/domain/user/dto/response/mypage/BasicInfoResponse.java
+++ b/src/main/java/org/example/weneedbe/domain/user/dto/response/mypage/BasicInfoResponse.java
@@ -15,9 +15,9 @@ public class BasicInfoResponse {
     private GetMyInfoResponse userInfo;
     private List<MyPageArticleInfoResponse> myOutputList;
 
-    public static BasicInfoResponse from(Boolean sameUser, GetMyInfoResponse userInfo, List<MyPageArticleInfoResponse> myOutputList) {
+    public static BasicInfoResponse from(String userNickname, Boolean sameUser, GetMyInfoResponse userInfo, List<MyPageArticleInfoResponse> myOutputList) {
         return BasicInfoResponse.builder()
-                .userNickname(userInfo.getNickname())
+                .userNickname(userNickname)
                 .sameUser(sameUser)
                 .userInfo(userInfo)
                 .myOutputList(myOutputList)

--- a/src/main/java/org/example/weneedbe/domain/user/dto/response/mypage/BasicInfoResponse.java
+++ b/src/main/java/org/example/weneedbe/domain/user/dto/response/mypage/BasicInfoResponse.java
@@ -1,0 +1,2 @@
+package org.example.weneedbe.domain.user.dto.response.mypage;public class BasicInfoResponse {
+}

--- a/src/main/java/org/example/weneedbe/domain/user/dto/response/mypage/BasicInfoResponse.java
+++ b/src/main/java/org/example/weneedbe/domain/user/dto/response/mypage/BasicInfoResponse.java
@@ -15,7 +15,7 @@ public class BasicInfoResponse {
     private GetMyInfoResponse userInfo;
     private List<MyPageArticleInfoResponse> myOutputList;
 
-    public static BasicInfoResponse from(String userNickname, Boolean sameUser, GetMyInfoResponse userInfo, List<MyPageArticleInfoResponse> myOutputList) {
+    public static BasicInfoResponse of(String userNickname, Boolean sameUser, GetMyInfoResponse userInfo, List<MyPageArticleInfoResponse> myOutputList) {
         return BasicInfoResponse.builder()
                 .userNickname(userNickname)
                 .sameUser(sameUser)

--- a/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
+++ b/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
@@ -83,7 +83,7 @@ public class UserService {
         GetMyInfoResponse userInfo = GetMyInfoResponse.from(user);
         List<MyPageArticleInfoResponse> myOutputList =  getOutputFromUser(user, articleType);
 
-        return BasicInfoResponse.from(userNickname, sameUser, userInfo, myOutputList);
+        return BasicInfoResponse.of(userNickname, sameUser, userInfo, myOutputList);
     }
 
     public EditMyInfoResponse editInfo(String authorizationHeader, MultipartFile profileImage, EditMyInfoRequest request) throws IOException{

--- a/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
+++ b/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
@@ -44,7 +44,7 @@ public class UserService {
         return userRepository.existsByNickname(nickName);
     }
 
-    public ResponseEntity<UserInfoResponse> setUserInfo(UserInfoRequest request, String authorizationHeader) throws Exception {
+    public ResponseEntity<UserInfoResponse> setInfo(UserInfoRequest request, String authorizationHeader) throws Exception {
         Long userId = getUserIdFromHeader(authorizationHeader);
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         try {
@@ -63,14 +63,14 @@ public class UserService {
         return new ResponseEntity<>(new UserInfoResponse(true, "상세 정보 입력 성공"), HttpStatus.OK);
     }
 
-    public GetMyInfoResponse getMyInfo(String authorizationHeader) {
+    public GetMyInfoResponse getInfo(String authorizationHeader) {
         Long userId = getUserIdFromHeader(authorizationHeader);
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
 
         return GetMyInfoResponse.from(user);
     }
 
-    public EditMyInfoResponse editMyInfo(String authorizationHeader, MultipartFile profileImage, EditMyInfoRequest request) throws IOException{
+    public EditMyInfoResponse editInfo(String authorizationHeader, MultipartFile profileImage, EditMyInfoRequest request) throws IOException{
         Long userId = getUserIdFromHeader(authorizationHeader);
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
 
@@ -110,7 +110,7 @@ public class UserService {
         }).collect(Collectors.toList());
     }
 
-    public List<MyPageArticleInfoResponse> getMyInfo(String authorizationHeader, Type articleType) {
+    public List<MyPageArticleInfoResponse> getArticleInfo(String authorizationHeader, Type articleType) {
         Long userId = getUserIdFromHeader(authorizationHeader);
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
 
@@ -126,7 +126,7 @@ public class UserService {
         }).collect(Collectors.toList());
     }
 
-    public GetMyInfoResponse getMyInfoFromUserId(Long userId) {
+    public GetMyInfoResponse getInfoFromUserId(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
 
         return GetMyInfoResponse.from(user);

--- a/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
+++ b/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
@@ -29,7 +29,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -123,7 +122,7 @@ public class UserService {
             return new MyPageArticleInfoResponse(s.getArticle(),
                     articleLikeRepository.countByArticle(s.getArticle()),
                     teamProfiles);
-        }).collect(Collectors.toList());
+        }).toList();
     }
 
     public List<MyPageArticleInfoResponse> getArticleInfo(String authorizationHeader, Type articleType) {
@@ -151,7 +150,7 @@ public class UserService {
         return userArticleRepository.findAllByArticle_ArticleId(articleId)
                 .stream()
                 .map(userArticle -> userArticle.getUser().getProfile())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private Long getUserIdFromHeader(String authorizationHeader) {

--- a/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
+++ b/src/main/java/org/example/weneedbe/domain/user/service/UserService.java
@@ -144,6 +144,20 @@ public class UserService {
                 .collect(Collectors.toList());
     }
 
+    public GetMyInfoResponse getMyInfoFromUserId(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+
+        return GetMyInfoResponse.from(user);
+    }
+
+    public boolean isSameUser(String authorizationHeader, Long userId) {
+        Long userIdFromHeader = getUserIdFromHeader(authorizationHeader);
+        if (userIdFromHeader.equals(userId)) {
+            return true;
+        }
+        return false;
+    }
+
     private Long getUserIdFromHeader(String authorizationHeader) {
         String token = tokenProvider.getTokenFromAuthorizationHeader(authorizationHeader);
         return tokenProvider.getUserIdFromToken(token);


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 게시글 상세 조회 페이지에서 글 작성자의 마이페이지를 가져오기 위함입니다.
- 불필요한 api를 방지하기 위해 삭제 및 통합하였습니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?
### 특정 API의 통합 및 변경
- 세부 정보 및 작성 게시글 조회 api를 하나로 통합하였습니다.
- DTO가 반환될 때 값의 변조를 막기 위해 `toList()` 로 반환 방식을 변경하였습니다.
<br>

## 3. 관련 스크린샷을 첨부해주세요.

### 유저가 동일한 경우 (`sameUser` = `true`)
<img width="1241" alt="스크린샷 2024-01-28 오후 6 04 22" src="https://github.com/Leets-Official/WeNeed-BE/assets/129377887/36ed2797-82a0-4c34-a2bb-c7ae01bee93c">


### 유저가 다른 경우 (`sameUser` = `false`)
<img width="1236" alt="스크린샷 2024-01-28 오후 6 04 38" src="https://github.com/Leets-Official/WeNeed-BE/assets/129377887/9e43a764-5a05-40ff-82f8-21f6ae35b785">


<br>

## 4. 완료 사항

### 23.01.28
- 기존의 `my-Info` api를 `basic-info`로 변경하였습니다.
  - 해당 api는 `my-info`와 `my-outputs` api의 통합 api입니다.
  - 해당 api는 헤더 및 주어진 userId의 비교를 통해 필요한 정보를 유동적으로 반환합니다.
  - 현재 로그인한 사용자의 닉네임을 따로 반환하도록 변경하였습니다.
  - 현재 로그인한 사용자와 이동하려는 유저의 마이페이지가 동일한 경우와 아닌 경우를 `sameUser` 변수를 통해 반환합니다.

- 불필요한 api를 삭제하였습니다.
  - 다른 사용자의 마이페이지 api, `my-outputs` api

close #64 

<br>

## 5. 추가 사항
