### PR TITLE
[fix] #72 게시물상세조회 content 관련 수정

### DIFF
--- a/src/main/java/org/example/weneedbe/domain/article/application/ArticleService.java
+++ b/src/main/java/org/example/weneedbe/domain/article/application/ArticleService.java
@@ -245,13 +245,13 @@ public class ArticleService {
         articleRepository.delete(article);
     }
 
-    private User findUser(String authorizationHeader){
+    public User findUser(String authorizationHeader){
         String token = tokenProvider.getTokenFromAuthorizationHeader(authorizationHeader);
         Long userId = tokenProvider.getUserIdFromToken(token);
         return userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
     }
 
-    private Article findArticle(Long articleId){
+    public Article findArticle(Long articleId){
         return articleRepository.findById(articleId)
                 .orElseThrow(ArticleNotFoundException::new);
     }

--- a/src/main/java/org/example/weneedbe/domain/article/application/MainService.java
+++ b/src/main/java/org/example/weneedbe/domain/article/application/MainService.java
@@ -186,7 +186,7 @@ public class MainService {
         StringBuilder allContent = new StringBuilder();
         for (ContentData data : contentData) {
             if ("text".equals(data.getType())) {
-                allContent.append(data.getTextData()).append(" ");
+                allContent.append(data.getType()).append(" ");
             }
         }
         return allContent.toString().trim();

--- a/src/main/java/org/example/weneedbe/domain/article/application/MainService.java
+++ b/src/main/java/org/example/weneedbe/domain/article/application/MainService.java
@@ -10,10 +10,7 @@ import org.example.weneedbe.domain.article.repository.ArticleRepository;
 import org.example.weneedbe.domain.bookmark.domain.Bookmark;
 import org.example.weneedbe.domain.bookmark.repository.BookmarkRepository;
 import org.example.weneedbe.domain.user.domain.User;
-import org.example.weneedbe.domain.user.exception.UserNotFoundException;
-import org.example.weneedbe.domain.user.exception.UserNotRegisteredException;
-import org.example.weneedbe.domain.user.repository.UserRepository;
-import org.example.weneedbe.global.jwt.TokenProvider;
+import org.example.weneedbe.domain.user.service.UserService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -27,11 +24,10 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class MainService {
-    private final UserRepository userRepository;
     private final ArticleRepository articleRepository;
     private final ArticleLikeRepository articleLikeRepository;
     private final BookmarkRepository bookmarkRepository;
-    private final TokenProvider tokenProvider;
+    private final UserService userService;
     private final static String SORT_BY_RECENT = "DESC";
     private final static String SORT_BY_HEARTS = "HEART";
     private final static String SORT_BY_VIEWS = "VIEW";
@@ -41,7 +37,7 @@ public class MainService {
         String guestNickname = "guest";
 
         if (authorizationHeader != null) {
-            user = getUserFromAuthorizationHeader(authorizationHeader);
+            user = userService.findUser(authorizationHeader);
         }
 
         Pageable pageable = PageRequest.of(page - 1, size);
@@ -145,7 +141,7 @@ public class MainService {
         String guestNickname = "guest";
 
         if (authorizationHeader != null) {
-            user = getUserFromAuthorizationHeader(authorizationHeader);
+            user = userService.findUser(authorizationHeader);
         }
 
         Pageable pageable = PageRequest.of(page - 1, size);
@@ -192,12 +188,6 @@ public class MainService {
         return allContent.toString().trim();
     }
 
-    private User getUserFromAuthorizationHeader(String authorizationHeader) {
-        String token = tokenProvider.getTokenFromAuthorizationHeader(authorizationHeader);
-        Long userIdFromToken = tokenProvider.getUserIdFromToken(token);
-        return userRepository.findById(userIdFromToken).orElseThrow(UserNotFoundException::new);
-    }
-
     private boolean containsBookmarkId(List<Bookmark> bookmarks, Long articleId) {
         for (Bookmark bookmark : bookmarks) {
             if (bookmark.getArticle().getArticleId().equals(articleId)) {
@@ -212,7 +202,7 @@ public class MainService {
         String guestNickname = "guest";
 
         if (authorizationHeader != null) {
-            user = getUserFromAuthorizationHeader(authorizationHeader);
+            user = userService.findUser(authorizationHeader);
         }
 
         Pageable pageable = PageRequest.of(page - 1, size);

--- a/src/main/java/org/example/weneedbe/domain/article/dto/response/DetailResponseDto.java
+++ b/src/main/java/org/example/weneedbe/domain/article/dto/response/DetailResponseDto.java
@@ -64,7 +64,6 @@ public class DetailResponseDto {
         private int bookmarkCount;
         private int commentCount;
         private List<String> skills;
-        private List<String> links;
         private List<String> tags;
         private List<String> files;
         private DetailWriterDto writer;
@@ -80,7 +79,6 @@ public class DetailResponseDto {
             this.bookmarkCount = bookmarkCount;
             this.commentCount = article.getCommentList().size();
             this.skills = article.getDetailSkills();
-            this.links = article.getArticleLinks();
             this.tags = article.getDetailTags();
             this.files = article.getFiles().stream()
                     .map(File::getFileUrl)
@@ -100,9 +98,9 @@ public class DetailResponseDto {
             contentDto.setId(contentData.getId());
             contentDto.setType(contentData.getType());
             if ("image".equals(contentData.getType())) {
-                contentDto.setImageData(contentData.getImageData());
+                contentDto.setImageData(contentData.getData());
             } else if ("text".equals(contentData.getType())) {
-                contentDto.setTextData(contentData.getTextData());
+                contentDto.setTextData(contentData.getData());
             }
             contentDtoList.add(contentDto);
         }
@@ -129,7 +127,7 @@ public class DetailResponseDto {
     @Getter
     @Setter
     public static class DetailPortfolioContentDto {
-        private Long id;
+        private String id;
         private String type;
         private String textData;
         private String imageData;

--- a/src/main/java/org/example/weneedbe/domain/article/dto/response/DetailResponseDto.java
+++ b/src/main/java/org/example/weneedbe/domain/article/dto/response/DetailResponseDto.java
@@ -97,15 +97,7 @@ public class DetailResponseDto {
             DetailPortfolioContentDto contentDto = new DetailPortfolioContentDto();
             contentDto.setId(contentData.getId());
             contentDto.setType(contentData.getType());
-            if ("image".equals(contentData.getType())) {
-                contentDto.setData(contentData.getData());
-            } else if ("text".equals(contentData.getType())) {
-                contentDto.setData(contentData.getData());
-            } else if ("link".equals(contentData.getType())){
-                contentDto.setData(contentData.getData());
-            } else if ("sound".equals(contentData.getType())) {
-                contentDto.setData(contentData.getData());
-            }
+            contentDto.setData(contentData.getData());
             contentDtoList.add(contentDto);
         }
         return contentDtoList;

--- a/src/main/java/org/example/weneedbe/domain/article/dto/response/DetailResponseDto.java
+++ b/src/main/java/org/example/weneedbe/domain/article/dto/response/DetailResponseDto.java
@@ -98,9 +98,13 @@ public class DetailResponseDto {
             contentDto.setId(contentData.getId());
             contentDto.setType(contentData.getType());
             if ("image".equals(contentData.getType())) {
-                contentDto.setImageData(contentData.getData());
+                contentDto.setData(contentData.getData());
             } else if ("text".equals(contentData.getType())) {
-                contentDto.setTextData(contentData.getData());
+                contentDto.setData(contentData.getData());
+            } else if ("link".equals(contentData.getType())){
+                contentDto.setData(contentData.getData());
+            } else if ("sound".equals(contentData.getType())) {
+                contentDto.setData(contentData.getData());
             }
             contentDtoList.add(contentDto);
         }
@@ -129,8 +133,7 @@ public class DetailResponseDto {
     public static class DetailPortfolioContentDto {
         private String id;
         private String type;
-        private String textData;
-        private String imageData;
+        private String data;
     }
 
     @Getter

--- a/src/main/java/org/example/weneedbe/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/org/example/weneedbe/domain/article/repository/ArticleRepository.java
@@ -53,6 +53,6 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     @Query("SELECT ar FROM Article ar WHERE ar.user = :user AND ar.articleType = 'PORTFOLIO'")
     List<Article> findPortfolioArticlesByUser(@Param("user") User user);
 
-    @Query("SELECT DISTINCT ar FROM Article ar JOIN ar.content c WHERE ar.title LIKE %:keyword% OR c.textData LIKE %:keyword% ORDER BY ar.createdAt DESC")
+    @Query("SELECT DISTINCT ar FROM Article ar JOIN ar.content c WHERE ar.title LIKE %:keyword% OR c.data LIKE %:keyword% ORDER BY ar.createdAt DESC")
     Page<Article> findAllByTitleOrTextDataContaining(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/org/example/weneedbe/domain/comment/api/CommentController.java
+++ b/src/main/java/org/example/weneedbe/domain/comment/api/CommentController.java
@@ -11,12 +11,7 @@ import org.example.weneedbe.domain.comment.dto.request.AddCommentRequest;
 import org.example.weneedbe.global.error.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/comments")
@@ -33,9 +28,9 @@ public class CommentController {
       @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
   @PostMapping("/{articleId}")
-  public ResponseEntity<Void> createComment(@PathVariable Long articleId,
-      @RequestBody AddCommentRequest request) {
-    commentService.createComment(articleId, request);
+  public ResponseEntity<Void> createComment(@RequestHeader("Authorization") String authorizationHeader,
+                                            @PathVariable Long articleId, @RequestBody AddCommentRequest request) {
+    commentService.createComment(authorizationHeader, articleId, request);
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 
@@ -47,9 +42,9 @@ public class CommentController {
       @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
   @DeleteMapping("/{articleId}/{commentId}")
-  public ResponseEntity<Void> deleteComment(@PathVariable Long articleId,
-      @PathVariable Long commentId) {
-    commentService.deleteComment(articleId, commentId);
+  public ResponseEntity<Void> deleteComment(@RequestHeader("Authorization") String authorizationHeader,
+                                            @PathVariable Long articleId, @PathVariable Long commentId) {
+    commentService.deleteComment(authorizationHeader, articleId, commentId);
     return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/org/example/weneedbe/domain/comment/application/CommentService.java
+++ b/src/main/java/org/example/weneedbe/domain/comment/application/CommentService.java
@@ -9,6 +9,8 @@ import org.example.weneedbe.domain.comment.dto.request.AddCommentRequest;
 import org.example.weneedbe.domain.comment.exception.CommentNotFoundException;
 import org.example.weneedbe.domain.comment.repository.CommentRepository;
 import org.example.weneedbe.domain.user.domain.User;
+import org.example.weneedbe.domain.user.service.UserService;
+import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,11 +20,12 @@ public class CommentService {
 
   private final CommentRepository commentRepository;
   private final ArticleService articleService;
+  private final UserService userService;
 
   @Transactional
   public void createComment(String authorizationHeader, Long articleId, AddCommentRequest request) {
     Article article = articleService.findArticle(articleId);
-    User user = articleService.findUser(authorizationHeader);
+    User user = userService.findUser(authorizationHeader);
 
     Comment comment = Comment.of(request, article, user);
 
@@ -38,7 +41,7 @@ public class CommentService {
 
   public void deleteComment(String authorizationHeader, Long articleId, Long commentId) {
     Article article = articleService.findArticle(articleId);
-    User user = articleService.findUser(authorizationHeader);
+    User user = userService.findUser(authorizationHeader);
 
     Comment comment = findComment(commentId);
 


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

- type이 image, text, link, sound인지 구분하여 해당 타입에 맞는 데이터와 타입을 함께 조회해서 반환하도록 합니다.
- 댓글 생성시 헤더의 토큰으로 유저id를 가져오는 로직으로 변경합니다.
- 댓글 삭제시 헤더의 토큰의 유저id와 댓글의 유저id 와 같은지 판단하고 아닐시 `AuthorMismatchException`을 발생시킵니다.
- articleservice에서 사용했던 `findUser`와 `findArticle`을 공통 메서드로 사용합니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="1329" alt="image" src="https://github.com/Leets-Official/WeNeed-BE/assets/108799865/f1ac7ea5-8f77-4ccb-ab46-2c9cb7b2e9cb">


<br>

## 4. 완료 사항

<br>

## 5. 추가 사항
close #71 