### PR TITLE
[feat] #75 검색조회시 프로필, 조회수여부, 북마크여부 로직 추가

### DIFF
--- a/src/main/java/org/example/weneedbe/domain/article/api/ArticleController.java
+++ b/src/main/java/org/example/weneedbe/domain/article/api/ArticleController.java
@@ -16,6 +16,7 @@ import org.example.weneedbe.domain.article.dto.request.ArticleRequest;
 import org.example.weneedbe.domain.article.dto.response.DetailResponseDto.DetailPortfolioDto;
 import org.example.weneedbe.domain.article.dto.response.DetailResponseDto.DetailRecruitDto;
 import org.example.weneedbe.domain.article.dto.response.MemberInfoResponse;
+import org.example.weneedbe.domain.bookmark.service.BookmarkService;
 import org.example.weneedbe.global.error.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,6 +29,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class ArticleController {
 
     private final ArticleService articleService;
+    private final BookmarkService bookmarkService;
 
     @Operation(summary = "포트폴리오 게시물 작성", description = "사용자가 포트폴리오 게시물을 작성합니다.")
     @ApiResponses({
@@ -101,7 +103,7 @@ public class ArticleController {
     })
     @PostMapping("/bookmarks/{articleId}")
     public ResponseEntity<Void> bookmarkArticle(@RequestHeader("Authorization") String authorizationHeader, @PathVariable Long articleId) {
-        articleService.bookmarkArticle(authorizationHeader, articleId);
+        bookmarkService.bookmarkArticle(authorizationHeader, articleId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/org/example/weneedbe/domain/article/api/ArticleController.java
+++ b/src/main/java/org/example/weneedbe/domain/article/api/ArticleController.java
@@ -16,7 +16,6 @@ import org.example.weneedbe.domain.article.dto.request.ArticleRequest;
 import org.example.weneedbe.domain.article.dto.response.DetailResponseDto.DetailPortfolioDto;
 import org.example.weneedbe.domain.article.dto.response.DetailResponseDto.DetailRecruitDto;
 import org.example.weneedbe.domain.article.dto.response.MemberInfoResponse;
-import org.example.weneedbe.domain.bookmark.service.BookmarkService;
 import org.example.weneedbe.global.error.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -29,7 +28,6 @@ import org.springframework.web.multipart.MultipartFile;
 public class ArticleController {
 
     private final ArticleService articleService;
-    private final BookmarkService bookmarkService;
 
     @Operation(summary = "포트폴리오 게시물 작성", description = "사용자가 포트폴리오 게시물을 작성합니다.")
     @ApiResponses({
@@ -103,7 +101,7 @@ public class ArticleController {
     })
     @PostMapping("/bookmarks/{articleId}")
     public ResponseEntity<Void> bookmarkArticle(@RequestHeader("Authorization") String authorizationHeader, @PathVariable Long articleId) {
-        bookmarkService.bookmarkArticle(authorizationHeader, articleId);
+        articleService.bookmarkArticle(authorizationHeader, articleId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/org/example/weneedbe/domain/article/application/ArticleService.java
+++ b/src/main/java/org/example/weneedbe/domain/article/application/ArticleService.java
@@ -19,6 +19,8 @@ import org.example.weneedbe.domain.article.exception.ArticleNotFoundException;
 import org.example.weneedbe.domain.article.exception.AuthorMismatchException;
 import org.example.weneedbe.domain.article.repository.ArticleLikeRepository;
 import org.example.weneedbe.domain.article.repository.ArticleRepository;
+import org.example.weneedbe.domain.bookmark.domain.Bookmark;
+import org.example.weneedbe.domain.bookmark.repository.BookmarkRepository;
 import org.example.weneedbe.domain.bookmark.service.BookmarkService;
 import org.example.weneedbe.domain.comment.domain.Comment;
 import org.example.weneedbe.domain.comment.repository.CommentRepository;
@@ -46,6 +48,7 @@ public class ArticleService {
     private final FileRepository fileRepository;
     private final UserService userService;
     private final BookmarkService bookmarkService;
+    private final BookmarkRepository bookmarkRepository;
 
     public void createPortfolio(String authorizationHeader, MultipartFile thumbnail, List<MultipartFile> images,
                                 List<MultipartFile> files, ArticleRequest request) throws IOException {
@@ -98,6 +101,19 @@ public class ArticleService {
         }
     }
 
+    public void bookmarkArticle(String authorizationHeader, Long articleId) {
+
+        User user = userService.findUser(authorizationHeader);
+        Article article = findArticle(articleId);
+
+        Optional<Bookmark> bookmark = bookmarkRepository.findByArticleAndUser(article, user);
+
+        if (bookmark.isEmpty()) {
+            bookmarkRepository.save(new Bookmark(user, article));
+        } else {
+            bookmarkRepository.delete(bookmark.get());
+        }
+    }
 
 
     public DetailPortfolioDto getDetailPortfolio(String authorizationHeader, Long articleId) {

--- a/src/main/java/org/example/weneedbe/domain/article/application/ArticleService.java
+++ b/src/main/java/org/example/weneedbe/domain/article/application/ArticleService.java
@@ -19,18 +19,15 @@ import org.example.weneedbe.domain.article.exception.ArticleNotFoundException;
 import org.example.weneedbe.domain.article.exception.AuthorMismatchException;
 import org.example.weneedbe.domain.article.repository.ArticleLikeRepository;
 import org.example.weneedbe.domain.article.repository.ArticleRepository;
-import org.example.weneedbe.domain.bookmark.domain.Bookmark;
-import org.example.weneedbe.domain.bookmark.repository.BookmarkRepository;
+import org.example.weneedbe.domain.bookmark.service.BookmarkService;
 import org.example.weneedbe.domain.comment.domain.Comment;
 import org.example.weneedbe.domain.comment.repository.CommentRepository;
 import org.example.weneedbe.domain.file.repository.FileRepository;
 import org.example.weneedbe.domain.user.domain.User;
 import org.example.weneedbe.domain.user.domain.UserArticle;
-import org.example.weneedbe.domain.user.exception.UserNotFoundException;
 import org.example.weneedbe.domain.user.repository.UserArticleRepository;
 import org.example.weneedbe.domain.user.repository.UserRepository;
 import org.example.weneedbe.domain.user.service.UserService;
-import org.example.weneedbe.global.jwt.TokenProvider;
 import org.example.weneedbe.global.s3.application.S3Service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,12 +41,11 @@ public class ArticleService {
     private final UserRepository userRepository;
     private final S3Service s3Service;
     private final ArticleLikeRepository articleLikeRepository;
-    private final BookmarkRepository bookmarkRepository;
-    private final TokenProvider tokenProvider;
     private final CommentRepository commentRepository;
     private final UserArticleRepository userArticleRepository;
     private final FileRepository fileRepository;
     private final UserService userService;
+    private final BookmarkService bookmarkService;
 
     public void createPortfolio(String authorizationHeader, MultipartFile thumbnail, List<MultipartFile> images,
                                 List<MultipartFile> files, ArticleRequest request) throws IOException {
@@ -102,19 +98,7 @@ public class ArticleService {
         }
     }
 
-    public void bookmarkArticle(String authorizationHeader, Long articleId) {
 
-        User user = userService.findUser(authorizationHeader);
-        Article article = findArticle(articleId);
-
-        Optional<Bookmark> bookmark = bookmarkRepository.findByArticleAndUser(article, user);
-
-        if (bookmark.isEmpty()) {
-            bookmarkRepository.save(new Bookmark(user, article));
-        } else {
-            bookmarkRepository.delete(bookmark.get());
-        }
-    }
 
     public DetailPortfolioDto getDetailPortfolio(String authorizationHeader, Long articleId) {
         User user = userService.findUser(authorizationHeader);
@@ -123,11 +107,11 @@ public class ArticleService {
         article.plusViewCount(article.getViewCount() + 1);
         articleRepository.save(article);
 
-        int heartCount = articleLikeRepository.countByArticle(article);
-        int bookmarkCount = bookmarkRepository.countByArticle(article);
+        int heartCount = countHeartByArticle(article);
+        int bookmarkCount = bookmarkService.countBookmarkByArticle(article);
 
-        boolean isHearted = articleLikeRepository.existsByArticleAndUser(article, user);
-        boolean isBookmarked = bookmarkRepository.existsByArticleAndUser(article, user);
+        boolean isHearted = isArticleLikedByUser(article, user);
+        boolean isBookmarked = bookmarkService.isArticleBookmarkedByUser(article, user);
 
         List<Article> portfolioArticlesByUser = articleRepository.findPortfolioArticlesByUser(article.getUser());
         List<Comment> commentList = commentRepository.findAllByArticle(article);
@@ -142,7 +126,7 @@ public class ArticleService {
         for (Article portfolio : userPortfolio) {
             /* 상세조회하는 게시물 제외하고 workList에 추가 */
             if (!portfolio.getArticleId().equals(article.getArticleId())) {
-                boolean bookmarked = bookmarkRepository.existsByArticleAndUser(portfolio, user);
+                boolean bookmarked = bookmarkService.isArticleBookmarkedByUser(portfolio, user);
                 workList.add(new WorkPortfolioArticleDto(portfolio, bookmarked));
             }
         }
@@ -156,11 +140,11 @@ public class ArticleService {
         article.plusViewCount(article.getViewCount() + 1);
         articleRepository.save(article);
 
-        int heartCount = articleLikeRepository.countByArticle(article);
-        int bookmarkCount = bookmarkRepository.countByArticle(article);
+        int heartCount = countHeartByArticle(article);
+        int bookmarkCount = bookmarkService.countBookmarkByArticle(article);
 
-        boolean isHearted = articleLikeRepository.existsByArticleAndUser(article, user);
-        boolean isBookmarked = bookmarkRepository.existsByArticleAndUser(article, user);
+        boolean isHearted = isArticleLikedByUser(article, user);
+        boolean isBookmarked = bookmarkService.isArticleBookmarkedByUser(article, user);
 
         List<Comment> commentList = commentRepository.findAllByArticle(article);
         List<CommentResponseDto> commentResponseDtos = mapToResponseDto(commentList);
@@ -256,5 +240,12 @@ public class ArticleService {
         if (!user.equals(article.getUser())) {
             throw new AuthorMismatchException();
         }
+    }
+    public boolean isArticleLikedByUser(Article article, User user){
+        return articleLikeRepository.existsByArticleAndUser(article, user);
+    }
+
+    public int countHeartByArticle(Article article){
+        return articleLikeRepository.countByArticle(article);
     }
 }

--- a/src/main/java/org/example/weneedbe/domain/article/application/MainService.java
+++ b/src/main/java/org/example/weneedbe/domain/article/application/MainService.java
@@ -225,6 +225,6 @@ public class MainService {
         int bookmarkCount = bookmarkService.countBookmarkByArticle(article);
         boolean isHearted = articleService.isArticleLikedByUser(article, user);
         boolean isBookmarked = bookmarkService.isArticleBookmarkedByUser(article, user);
-        return new SearchArticleDto(article, heartCount, bookmarkCount, isHearted, isBookmarked);
+        return new SearchArticleDto(article, heartCount, bookmarkCount, isBookmarked, isHearted);
     }
 }

--- a/src/main/java/org/example/weneedbe/domain/article/dto/response/main/SearchArticleDto.java
+++ b/src/main/java/org/example/weneedbe/domain/article/dto/response/main/SearchArticleDto.java
@@ -12,23 +12,29 @@ public class SearchArticleDto {
     private String thumbnail;
     private String title;
     private List<String> detailTags;
+    private String profile;
     private String writerNickname;
     private Department major;
     private Integer grade;
     private int viewCount;
     private int heartCount;
     private int bookmarkCount;
+    private boolean isBookmarked;
+    private boolean isHearted;
 
-    public SearchArticleDto(Article article, int heartCount, int bookmarkCount){
+    public SearchArticleDto(Article article, int heartCount, int bookmarkCount, boolean isBookmarked, boolean isHearted){
         this.articleId = article.getArticleId();
         this.thumbnail = article.getThumbnail();
         this.title = article.getTitle();
         this.detailTags = article.getDetailTags();
+        this.profile = article.getUser().getProfile();
         this.writerNickname = article.getUser().getNickname();
         this.major = article.getUser().getMajor();
         this.grade = article.getUser().getGrade();
         this.viewCount = article.getViewCount();
         this.heartCount = heartCount;
         this.bookmarkCount = bookmarkCount;
+        this.isBookmarked = isBookmarked;
+        this.isHearted = isHearted;
     }
 }

--- a/src/main/java/org/example/weneedbe/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/org/example/weneedbe/domain/bookmark/service/BookmarkService.java
@@ -1,36 +1,16 @@
 package org.example.weneedbe.domain.bookmark.service;
 
 import lombok.RequiredArgsConstructor;
-import org.example.weneedbe.domain.article.application.ArticleService;
 import org.example.weneedbe.domain.article.domain.Article;
-import org.example.weneedbe.domain.bookmark.domain.Bookmark;
 import org.example.weneedbe.domain.bookmark.repository.BookmarkRepository;
 import org.example.weneedbe.domain.user.domain.User;
-import org.example.weneedbe.domain.user.service.UserService;
 import org.springframework.stereotype.Service;
-
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class BookmarkService {
     private final BookmarkRepository bookmarkRepository;
-    private final UserService userService;
-    private final ArticleService articleService;
 
-    public void bookmarkArticle(String authorizationHeader, Long articleId) {
-
-        User user = userService.findUser(authorizationHeader);
-        Article article = articleService.findArticle(articleId);
-
-        Optional<Bookmark> bookmark = bookmarkRepository.findByArticleAndUser(article, user);
-
-        if (bookmark.isEmpty()) {
-            bookmarkRepository.save(new Bookmark(user, article));
-        } else {
-            bookmarkRepository.delete(bookmark.get());
-        }
-    }
     public boolean isArticleBookmarkedByUser(Article article, User user){
         return bookmarkRepository.existsByArticleAndUser(article, user);
     }

--- a/src/main/java/org/example/weneedbe/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/org/example/weneedbe/domain/bookmark/service/BookmarkService.java
@@ -1,0 +1,41 @@
+package org.example.weneedbe.domain.bookmark.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.weneedbe.domain.article.application.ArticleService;
+import org.example.weneedbe.domain.article.domain.Article;
+import org.example.weneedbe.domain.bookmark.domain.Bookmark;
+import org.example.weneedbe.domain.bookmark.repository.BookmarkRepository;
+import org.example.weneedbe.domain.user.domain.User;
+import org.example.weneedbe.domain.user.service.UserService;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class BookmarkService {
+    private final BookmarkRepository bookmarkRepository;
+    private final UserService userService;
+    private final ArticleService articleService;
+
+    public void bookmarkArticle(String authorizationHeader, Long articleId) {
+
+        User user = userService.findUser(authorizationHeader);
+        Article article = articleService.findArticle(articleId);
+
+        Optional<Bookmark> bookmark = bookmarkRepository.findByArticleAndUser(article, user);
+
+        if (bookmark.isEmpty()) {
+            bookmarkRepository.save(new Bookmark(user, article));
+        } else {
+            bookmarkRepository.delete(bookmark.get());
+        }
+    }
+    public boolean isArticleBookmarkedByUser(Article article, User user){
+        return bookmarkRepository.existsByArticleAndUser(article, user);
+    }
+
+    public int countBookmarkByArticle(Article article){
+        return bookmarkRepository.countByArticle(article);
+    }
+}


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
메인페이지 검색 시, 해당 게시물 유저의 profile 데이터를 추가합니다.
각 게시물에서 '나'(보는 유저)의 북마크여부, 좋아요 여부를 추가합니다.
비로그인유저의 경우(nickname:guest) 좋아요와 북마크여부는 항상 false 로 반환합니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
![image](https://github.com/Leets-Official/WeNeed-BE/assets/108799865/ae1e5452-d9b5-46c4-9c7a-4bf68567cc31)


<br>

## 4. 완료 사항

<br>

## 5. 추가 사항
close #74 
