### PR TITLE
[feat] #83 메인페이지 전체와 태그조회 api 분리

### DIFF
--- a/src/main/java/org/example/weneedbe/domain/article/api/MainController.java
+++ b/src/main/java/org/example/weneedbe/domain/article/api/MainController.java
@@ -21,7 +21,20 @@ import org.springframework.web.bind.annotation.*;
 public class MainController {
     private final MainService mainService;
 
-    @Operation(summary = "메인페이지 - 포트폴리오", description = "메인페이지에서 포트폴리오부분 조회합니다")
+    @Operation(summary = "메인페이지 - 포트폴리오(전체조회)", description = "메인페이지에서 포트폴리오부분(전체) 조회합니다")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/portfolio/all")
+    ResponseEntity<MainPortfolioDto> getMainPagePortfolioAll(
+            @RequestParam int size, @RequestParam int page, @RequestParam(defaultValue = "DESC") String sort, @RequestParam(required = false, defaultValue = "ALL") String detailTags,
+            @RequestHeader(name = "Authorization", required = false)  String authorizationHeader) {
+        return ResponseEntity.ok(mainService.getPortfolioArticleList(size, page, sort, detailTags, authorizationHeader));
+    }
+    @Operation(summary = "메인페이지 - 포트폴리오(태그조회)", description = "메인페이지에서 포트폴리오부분(태그포함) 조회합니다")
     @ApiResponses({
             @ApiResponse(responseCode = "200"),
             @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
@@ -30,12 +43,26 @@ public class MainController {
     })
     @GetMapping("/portfolio")
     ResponseEntity<MainPortfolioDto> getMainPagePortfolio(
-            @RequestParam int size, @RequestParam int page, @RequestParam(defaultValue = "DESC") String sort, @RequestParam(required = false, defaultValue = "") String detailTags,
+            @RequestParam int size, @RequestParam int page, @RequestParam(defaultValue = "DESC") String sort, @RequestParam(required = false) String detailTags,
             @RequestHeader(name = "Authorization", required = false)  String authorizationHeader) {
         return ResponseEntity.ok(mainService.getPortfolioArticleList(size, page, sort, detailTags, authorizationHeader));
     }
 
-    @Operation(summary = "메인페이지 - 리크루팅", description = "메인페이지에서 리크루팅 조회합니다")
+    @Operation(summary = "메인페이지 - 리크루팅(전체조회)", description = "메인페이지에서 리크루팅(전체) 조회합니다")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/recruit/all")
+    ResponseEntity<MainRecruitDto> getMainPageRecruitAll(
+            @RequestParam int size, @RequestParam int page, @RequestParam(required = false, defaultValue = "ALL") String detailTags,
+            @RequestHeader(name = "Authorization", required = false)  String authorizationHeader) {
+        return ResponseEntity.ok(mainService.getRecruitArticleList(size, page, detailTags, authorizationHeader));
+    }
+
+    @Operation(summary = "메인페이지 - 리크루팅(태그조회)", description = "메인페이지에서 리크루팅(태그포함) 조회합니다")
     @ApiResponses({
             @ApiResponse(responseCode = "200"),
             @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
@@ -44,7 +71,7 @@ public class MainController {
     })
     @GetMapping("/recruit")
     ResponseEntity<MainRecruitDto> getMainPageRecruit(
-            @RequestParam int size, @RequestParam int page, @RequestParam(required = false, defaultValue = "") String detailTags,
+            @RequestParam int size, @RequestParam int page, @RequestParam(required = false) String detailTags,
             @RequestHeader(name = "Authorization", required = false)  String authorizationHeader) {
         return ResponseEntity.ok(mainService.getRecruitArticleList(size, page, detailTags, authorizationHeader));
     }

--- a/src/main/java/org/example/weneedbe/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/org/example/weneedbe/domain/article/repository/ArticleRepository.java
@@ -1,6 +1,7 @@
 package org.example.weneedbe.domain.article.repository;
 
 import org.example.weneedbe.domain.article.domain.Article;
+import org.example.weneedbe.domain.article.domain.Type;
 import org.example.weneedbe.domain.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,8 +15,8 @@ import java.util.List;
 @Repository
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 
-    @Query(value = "SELECT a.* FROM article a LEFT JOIN detail_tags dt ON a.article_id = dt.article_id AND (:detailTags IS NULL OR dt.detail_tags IN :detailTags) WHERE a.article_type = 'PORTFOLIO' ORDER BY a.created_at DESC",
-            countQuery = "SELECT count(*) FROM article a LEFT JOIN detail_tags dt ON a.article_id = dt.article_id AND (:detailTags IS NULL OR dt.detail_tags IN :detailTags) WHERE a.article_type = 'PORTFOLIO'",
+    @Query(value = "SELECT a.* FROM article a LEFT JOIN detail_tags dt ON a.article_id = dt.article_id WHERE a.article_type = 'PORTFOLIO' AND dt.detail_tags IN :detailTags ORDER BY a.created_at DESC",
+            countQuery = "SELECT count(*) FROM article a LEFT JOIN detail_tags dt ON a.article_id = dt.article_id WHERE a.article_type = 'PORTFOLIO' AND dt.detail_tags IN :detailTags",
             nativeQuery = true)
     Page<Article> findPortfoliosByDetailTagsInOrderByCreatedAtDesc(@Param("detailTags") String[] detailTags, Pageable pageable);
 
@@ -23,19 +24,19 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
             "FROM article ar " +
             "LEFT JOIN detail_tags dt ON ar.article_id = dt.article_id " +
             "LEFT JOIN article_like h ON ar.article_id = h.article_id " +
-            "AND (:detailTags IS NULL OR dt.detail_tags IN :detailTags) WHERE ar.article_type = 'PORTFOLIO'" +
+            "WHERE ar.article_type = 'PORTFOLIO' AND dt.detail_tags IN :detailTags" +
             "GROUP BY ar.article_id " +
             "ORDER BY COUNT(h.article_id) DESC",
             countQuery = "SELECT COUNT(DISTINCT ar.article_id) " +
                     "FROM article ar " +
                     "LEFT JOIN detail_tags dt ON ar.article_id = dt.article_id " +
                     "LEFT JOIN article_like h ON ar.article_id = h.article_id " +
-                    "AND (:detailTags IS NULL OR dt.detail_tags IN :detailTags) WHERE ar.article_type = 'PORTFOLIO'",
+                    "WHERE ar.article_type = 'PORTFOLIO' AND dt.detail_tags IN :detailTags",
             nativeQuery = true)
     Page<Article> findPortfoliosByDetailTagsOrderByLikesDesc(@Param("detailTags") String[] detailTags, Pageable pageable);
 
-    @Query(value = "SELECT a.* FROM article a LEFT JOIN detail_tags dt ON a.article_id = dt.article_id AND (:detailTags IS NULL OR dt.detail_tags IN :detailTags) WHERE a.article_type = 'PORTFOLIO' ORDER BY a.view_count DESC",
-            countQuery = "SELECT count(*) FROM article a LEFT JOIN detail_tags dt ON a.article_id = dt.article_id AND (:detailTags IS NULL OR dt.detail_tags IN :detailTags) WHERE a.article_type = 'PORTFOLIO'",
+    @Query(value = "SELECT a.* FROM article a LEFT JOIN detail_tags dt ON a.article_id = dt.article_id WHERE a.article_type = 'PORTFOLIO' AND dt.detail_tags IN :detailTags ORDER BY a.view_count DESC",
+            countQuery = "SELECT count(*) FROM article a LEFT JOIN detail_tags dt ON a.article_id = dt.article_id WHERE a.article_type = 'PORTFOLIO' AND dt.detail_tags IN :detailTags",
             nativeQuery = true)
     Page<Article> findPortfoliosByDetailTagsInOrderByViewCountDesc(@Param("detailTags") String[] detailTags, Pageable pageable);
 
@@ -45,8 +46,8 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     @Query("SELECT ar FROM Article ar WHERE ar.articleType = 'PORTFOLIO'")
     List<Article> findPortfolios();
 
-    @Query(value = "SELECT a.* FROM article a LEFT JOIN detail_tags dt ON a.article_id = dt.article_id AND (:detailTags IS NULL OR dt.detail_tags IN :detailTags) WHERE a.article_type = 'RECRUITING' ORDER BY a.created_at DESC",
-            countQuery = "SELECT count(*) FROM article a LEFT JOIN detail_tags dt ON a.article_id = dt.article_id AND (:detailTags IS NULL OR dt.detail_tags IN :detailTags) WHERE a.article_type = 'RECRUITING' ",
+    @Query(value = "SELECT a.* FROM article a LEFT JOIN detail_tags dt ON a.article_id = dt.article_id WHERE a.article_type = 'RECRUITING' AND dt.detail_tags IN :detailTags ORDER BY a.created_at DESC",
+            countQuery = "SELECT count(*) FROM article a LEFT JOIN detail_tags dt ON a.article_id = dt.article_id WHERE a.article_type = 'RECRUITING' AND dt.detail_tags IN :detailTags ",
             nativeQuery = true)
     Page<Article> findRecruitingByDetailTagsInOrderByCreatedAtDesc(@Param("detailTags") String[] detailTags, Pageable pageable);
 
@@ -55,4 +56,14 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 
     @Query("SELECT DISTINCT ar FROM Article ar JOIN ar.content c WHERE ar.title LIKE %:keyword% OR c.data LIKE %:keyword% ORDER BY ar.createdAt DESC")
     Page<Article> findAllByTitleOrTextDataContaining(@Param("keyword") String keyword, Pageable pageable);
+
+    @Query("SELECT ar FROM Article ar WHERE ar.articleType = :articleType ORDER BY ar.createdAt DESC")
+    Page<Article> findAllByTypeOrderByCreatedAtDesc(@Param("articleType") Type articleType, Pageable pageable);
+    @Query("SELECT ar FROM Article ar LEFT JOIN ar.likeList al WHERE ar.articleType = 'PORTFOLIO' ORDER BY SIZE(ar.likeList) DESC")
+    Page<Article> findAllByPortfolioTypeOrderByLikesDesc(Pageable pageable);
+    @Query("SELECT ar FROM Article ar WHERE ar.articleType = 'PORTFOLIO' ORDER BY ar.viewCount DESC")
+    Page<Article> findAllByPortfolioTypeOrderByViewCountDesc(Pageable pageable);
+
+
+
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
아무것도 태그를 선택하지 않은 조회와 태그를 선택하여 필터링하는 조회가 쿼리상 함께 조회하기 불가능하여 API를 분리합니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
<태그선택했을 시>
![image](https://github.com/Leets-Official/WeNeed-BE/assets/108799865/35cb70b7-c147-4909-a336-3f77c19bfb05)

<전체조회시>
![image](https://github.com/Leets-Official/WeNeed-BE/assets/108799865/3b5d18c9-2112-4593-b692-7b029bacc1c5)
<br>

## 4. 완료 사항
메인페이지 -> 포트폴리오 부분에서 전체조회와 태그포함조회로 나눕니다.
메인페이지 -> 리크루팅 부분에서 전체조회와 태그포함조회로 나눕니다.

<br>

## 5. 추가 사항
close #82 
