### PR TITLE
[feat] #91 리크루팅 조회 반환 dto 수정

### DIFF
--- a/src/main/java/org/example/weneedbe/domain/article/application/MainService.java
+++ b/src/main/java/org/example/weneedbe/domain/article/application/MainService.java
@@ -201,6 +201,7 @@ public class MainService {
                 .thumbnail(article.getThumbnail())
                 .title(article.getTitle())
                 .content(contentByListContent)
+                .sharedText(article.getSharedText())
                 .createdAt(article.getCreatedAt())
                 .viewCount(article.getViewCount())
                 .bookmarkCount(bookmarkCount)

--- a/src/main/java/org/example/weneedbe/domain/article/dto/response/DetailResponseDto.java
+++ b/src/main/java/org/example/weneedbe/domain/article/dto/response/DetailResponseDto.java
@@ -68,6 +68,7 @@ public class DetailResponseDto {
         private List<String> skills;
         private List<String> tags;
         private List<String> files;
+        private String sharedText;
         private DetailWriterDto writer;
         private List<DetailPortfolioContentDto> contents;
         private List<DetailTeamMemberDto> teamMembers;
@@ -85,6 +86,7 @@ public class DetailResponseDto {
             this.files = article.getFiles().stream()
                     .map(File::getFileUrl)
                     .collect(Collectors.toList());
+            this.sharedText = article.getSharedText();
             this.writer = new DetailWriterDto(article);
             this.contents = getPortfolioContents(article.getContent());
             this.teamMembers = article.getUserArticles().stream()

--- a/src/main/java/org/example/weneedbe/domain/article/dto/response/main/RecruitArticleDto.java
+++ b/src/main/java/org/example/weneedbe/domain/article/dto/response/main/RecruitArticleDto.java
@@ -20,6 +20,7 @@ public class RecruitArticleDto {
     private String title;
     private String thumbnail;
     private String content;
+    private String sharedText;
     private int commentCount;
     private int viewCount;
     private int heartCount;


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
게시물작성에 추가된 데이터를 조회때 반환하도록 dto를 수정합니다.
추가데이터가 반영된 API는 메인페이지조회-리크루팅, 게시물상세조회-리크루팅 입니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
![image](https://github.com/Leets-Official/WeNeed-BE/assets/108799865/ebf90ec0-6c73-4220-96c8-0e7ec348153b)


<br>

## 4. 완료 사항

- [x] 메인페이지 - 리크루팅(전체)조회
- [x] 메인페이지 - 리크루팅(태그포함)조회
- [x] 리크루팅 게시물 상세조회

<br>

## 5. 추가 사항
close #89 
