### PR TITLE
[feat] #94 지원 지원서 작성 API 구현

### DIFF
--- a/src/main/java/org/example/weneedbe/domain/application/api/ApplicationController.java
+++ b/src/main/java/org/example/weneedbe/domain/application/api/ApplicationController.java
@@ -64,7 +64,7 @@ public class ApplicationController {
           @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
           @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
-  @PostMapping(value = "/applicationForms/{recruitId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  @PostMapping(value = "/application-forms/{recruitId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<Void> createApplicationForm(
           @RequestHeader("Authorization") String authorizationHeader, @PathVariable Long recruitId,
           @RequestPart ApplicationFormRequest request, @RequestPart MultipartFile appeal) throws IOException {

--- a/src/main/java/org/example/weneedbe/domain/application/api/ApplicationController.java
+++ b/src/main/java/org/example/weneedbe/domain/application/api/ApplicationController.java
@@ -13,6 +13,7 @@ import org.example.weneedbe.domain.application.dto.request.RecruitFormRequest;
 import org.example.weneedbe.domain.application.dto.response.RecruitFormResponse;
 import org.example.weneedbe.global.error.ErrorResponse;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -63,7 +64,7 @@ public class ApplicationController {
           @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
           @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
   })
-  @PostMapping("/applicationForms/{recruitId}")
+  @PostMapping(value = "/applicationForms/{recruitId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<Void> createApplicationForm(
           @RequestHeader("Authorization") String authorizationHeader, @PathVariable Long recruitId,
           @RequestBody ApplicationFormRequest request, @RequestPart MultipartFile appeal) throws IOException {

--- a/src/main/java/org/example/weneedbe/domain/application/api/ApplicationController.java
+++ b/src/main/java/org/example/weneedbe/domain/application/api/ApplicationController.java
@@ -8,17 +8,16 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.example.weneedbe.domain.application.application.ApplicationService;
+import org.example.weneedbe.domain.application.dto.request.ApplicationFormRequest;
 import org.example.weneedbe.domain.application.dto.request.RecruitFormRequest;
 import org.example.weneedbe.domain.application.dto.response.RecruitFormResponse;
 import org.example.weneedbe.global.error.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @Tag(name = "Application Controller", description = "지원서 관련 API입니다.")
 @RestController
@@ -56,4 +55,21 @@ public class ApplicationController {
 
     return ResponseEntity.ok(applicationService.getRecruitForm(authorizationHeader, articleId));
   }
+
+  @Operation(summary = "지원서 작성", description = "게시물 모집에 대해 사용자가 지원합니다.")
+  @ApiResponses({
+          @ApiResponse(responseCode = "201"),
+          @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+          @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  @PostMapping("/applicationForms/{recruitId}")
+  public ResponseEntity<Void> createApplicationForm(
+          @RequestHeader("Authorization") String authorizationHeader, @PathVariable Long recruitId,
+          @RequestBody ApplicationFormRequest request, @RequestPart MultipartFile appeal) throws IOException {
+
+    applicationService.createApplicationForm(authorizationHeader, recruitId, appeal, request);
+    return ResponseEntity.status(HttpStatus.CREATED).build();
+  }
+
 }

--- a/src/main/java/org/example/weneedbe/domain/application/api/ApplicationController.java
+++ b/src/main/java/org/example/weneedbe/domain/application/api/ApplicationController.java
@@ -67,7 +67,7 @@ public class ApplicationController {
   @PostMapping(value = "/applicationForms/{recruitId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<Void> createApplicationForm(
           @RequestHeader("Authorization") String authorizationHeader, @PathVariable Long recruitId,
-          @RequestBody ApplicationFormRequest request, @RequestPart MultipartFile appeal) throws IOException {
+          @RequestPart ApplicationFormRequest request, @RequestPart MultipartFile appeal) throws IOException {
 
     applicationService.createApplicationForm(authorizationHeader, recruitId, appeal, request);
     return ResponseEntity.status(HttpStatus.CREATED).build();

--- a/src/main/java/org/example/weneedbe/domain/application/application/ApplicationService.java
+++ b/src/main/java/org/example/weneedbe/domain/application/application/ApplicationService.java
@@ -57,7 +57,7 @@ public class ApplicationService {
   public void createApplicationForm(String authorizationHeader, Long recruitId, MultipartFile appeal, ApplicationFormRequest request) throws IOException {
     User user = userService.findUser(authorizationHeader);
     Recruit recruit = recruitRepository.findById(recruitId).orElseThrow(RecruitNotFoundException::new);
-    String appealUrl = s3Service.uploadImage(appeal);
+    String appealUrl = s3Service.uploadFile(appeal);
 
     Application application = Application.of(recruit, user, request, appealUrl);
 

--- a/src/main/java/org/example/weneedbe/domain/application/domain/Application.java
+++ b/src/main/java/org/example/weneedbe/domain/application/domain/Application.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.example.weneedbe.domain.application.dto.request.ApplicationFormRequest;
+import org.example.weneedbe.domain.user.domain.Department;
 import org.example.weneedbe.domain.user.domain.User;
 import org.example.weneedbe.global.shared.entity.BaseTimeEntity;
 
@@ -27,10 +28,10 @@ public class Application extends BaseTimeEntity {
     private String name;
 
     @Column(nullable = false)
-    private String major;
+    private Department major;
 
     @Column(nullable = false)
-    private String doubleMajor;
+    private Department doubleMajor;
 
     @Column(nullable = false)
     private boolean international;

--- a/src/main/java/org/example/weneedbe/domain/application/domain/Application.java
+++ b/src/main/java/org/example/weneedbe/domain/application/domain/Application.java
@@ -29,6 +29,7 @@ public class Application extends BaseTimeEntity {
     @Column(nullable = false)
     private String major;
 
+    @Column(nullable = false)
     private String doubleMajor;
 
     @Column(nullable = false)

--- a/src/main/java/org/example/weneedbe/domain/application/domain/Application.java
+++ b/src/main/java/org/example/weneedbe/domain/application/domain/Application.java
@@ -27,9 +27,11 @@ public class Application extends BaseTimeEntity {
     @Column(nullable = false)
     private String name;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Department major;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Department doubleMajor;
 

--- a/src/main/java/org/example/weneedbe/domain/application/domain/Application.java
+++ b/src/main/java/org/example/weneedbe/domain/application/domain/Application.java
@@ -1,0 +1,2 @@
+package org.example.weneedbe.domain.application.domain;public class Application {
+}

--- a/src/main/java/org/example/weneedbe/domain/application/domain/Application.java
+++ b/src/main/java/org/example/weneedbe/domain/application/domain/Application.java
@@ -1,2 +1,88 @@
-package org.example.weneedbe.domain.application.domain;public class Application {
+package org.example.weneedbe.domain.application.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.weneedbe.domain.application.dto.request.ApplicationFormRequest;
+import org.example.weneedbe.domain.user.domain.User;
+import org.example.weneedbe.global.shared.entity.BaseTimeEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Application extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long applicationId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String major;
+
+    private String doubleMajor;
+
+    @Column(nullable = false)
+    private boolean international;
+
+    @Column(nullable = false)
+    private Integer grade;
+
+    @Column(nullable = false)
+    private String status;
+
+    @Column(nullable = false)
+    private String phone;
+
+    @Column(nullable = false)
+    private String aboutMe;
+
+    @Column(nullable = false)
+    private String appeal;
+
+    @Column(nullable = false)
+    private String content;
+
+    @ElementCollection
+    @CollectionTable(name = "application_keywords", joinColumns = @JoinColumn(name = "application_id"))
+    private List<String> keywords = new ArrayList<>();
+
+    @ElementCollection
+    @CollectionTable(name = "crew_answers", joinColumns = @JoinColumn(name = "application_id"))
+    private List<String> crewAnswers = new ArrayList<>();
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recruit_id")
+    private Recruit recruit;
+
+    public static Application of(Recruit recruit, User user, ApplicationFormRequest request, String appeal){
+        return Application.builder()
+                .name(request.getName())
+                .major(request.getMajor())
+                .doubleMajor(request.getDoubleMajor())
+                .international(request.isInternational())
+                .grade(request.getGrade())
+                .status(request.getStatus())
+                .phone(request.getPhone())
+                .aboutMe(request.getAboutMe())
+                .appeal(appeal)
+                .content(request.getContent())
+                .keywords(request.getKeywords())
+                .crewAnswers(request.getCrewAnswers())
+                .recruit(recruit)
+                .user(user).build();
+    }
 }

--- a/src/main/java/org/example/weneedbe/domain/application/domain/Recruit.java
+++ b/src/main/java/org/example/weneedbe/domain/application/domain/Recruit.java
@@ -55,7 +55,7 @@ public class Recruit extends BaseTimeEntity {
   private String content;
 
   @ElementCollection
-  @CollectionTable(name = "keywords", joinColumns = @JoinColumn(name = "recruit_id"))
+  @CollectionTable(name = "recruit_keywords", joinColumns = @JoinColumn(name = "recruit_id"))
   private List<String> keywords = new ArrayList<>();
 
   @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/example/weneedbe/domain/application/dto/request/ApplicationFormRequest.java
+++ b/src/main/java/org/example/weneedbe/domain/application/dto/request/ApplicationFormRequest.java
@@ -1,0 +1,2 @@
+package org.example.weneedbe.domain.application.dto.request;public class ApplicationFormRequest {
+}

--- a/src/main/java/org/example/weneedbe/domain/application/dto/request/ApplicationFormRequest.java
+++ b/src/main/java/org/example/weneedbe/domain/application/dto/request/ApplicationFormRequest.java
@@ -1,14 +1,16 @@
 package org.example.weneedbe.domain.application.dto.request;
 
 import lombok.Getter;
+import org.example.weneedbe.domain.user.domain.Department;
+
 import java.util.List;
 
 @Getter
 public class ApplicationFormRequest {
 
     private String name;
-    private String major;
-    private String doubleMajor;
+    private Department major;
+    private Department doubleMajor;
     private boolean international;
     private Integer grade;
     private String status;

--- a/src/main/java/org/example/weneedbe/domain/application/dto/request/ApplicationFormRequest.java
+++ b/src/main/java/org/example/weneedbe/domain/application/dto/request/ApplicationFormRequest.java
@@ -1,2 +1,21 @@
-package org.example.weneedbe.domain.application.dto.request;public class ApplicationFormRequest {
+package org.example.weneedbe.domain.application.dto.request;
+
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+public class ApplicationFormRequest {
+
+    private String name;
+    private String major;
+    private String doubleMajor;
+    private boolean international;
+    private Integer grade;
+    private String status;
+    private String phone;
+    private String aboutMe;
+    private String content;
+    private List<String> keywords;
+    private List<String> crewAnswers;
+
 }

--- a/src/main/java/org/example/weneedbe/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/org/example/weneedbe/domain/application/repository/ApplicationRepository.java
@@ -1,0 +1,2 @@
+package org.example.weneedbe.domain.application.repository;public interface ApplicationRepository {
+}

--- a/src/main/java/org/example/weneedbe/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/org/example/weneedbe/domain/application/repository/ApplicationRepository.java
@@ -1,2 +1,7 @@
-package org.example.weneedbe.domain.application.repository;public interface ApplicationRepository {
+package org.example.weneedbe.domain.application.repository;
+
+import org.example.weneedbe.domain.application.domain.Application;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApplicationRepository extends JpaRepository<Application, Long> {
 }

--- a/src/main/java/org/example/weneedbe/global/error/ErrorCode.java
+++ b/src/main/java/org/example/weneedbe/global/error/ErrorCode.java
@@ -20,7 +20,8 @@ public enum ErrorCode {
     USER_NOT_REGISTERED(400, "USER_NOT_REGISTERED","회원가입이 완료되지 않은 유저입니다."),
     AUTHOR_MISMATCH_ERROR(400, "AUTHOR_MISMATCH_ERROR", "작성자와 사용자가 일치하지 않습니다."),
     TOKEN_NOT_FOUND(400, "TOKEN_NOT_FOUND", "해당 유저의 리프레시 토큰을 찾을 수 없습니다."),
-    RECRUIT_NOT_FOUND_EXCEPTION(400, "RECRUIT_NOT_FOUND_EXCEPTION", "존재하지 않는 모집 지원서입니다.");
+    RECRUIT_NOT_FOUND_EXCEPTION(400, "RECRUIT_NOT_FOUND_EXCEPTION", "존재하지 않는 모집 지원서입니다."),
+    INVALID_FILE(400, "INVALID_FILE", "PDF 파일만 가능합니다.");
 
     private final int httpStatus;
     private final String code;

--- a/src/main/java/org/example/weneedbe/global/s3/application/S3Service.java
+++ b/src/main/java/org/example/weneedbe/global/s3/application/S3Service.java
@@ -116,9 +116,8 @@ public class S3Service {
         throw new FileUploadErrorException();
       }
       return getS3(bucketName, fileName);
-    }else {
-      throw new InvalidFileException();
     }
+    throw new InvalidFileException();
   }
 
   public String createFileName(String fileName){

--- a/src/main/java/org/example/weneedbe/global/s3/exception/InvalidFileException.java
+++ b/src/main/java/org/example/weneedbe/global/s3/exception/InvalidFileException.java
@@ -1,2 +1,10 @@
-package org.example.weneedbe.global.s3.exception;public class InvalidFileException {
+package org.example.weneedbe.global.s3.exception;
+
+import org.example.weneedbe.global.error.ErrorCode;
+import org.example.weneedbe.global.error.exception.ServiceException;
+
+public class InvalidFileException extends ServiceException {
+    public InvalidFileException() {
+        super(ErrorCode.INVALID_FILE);
+    }
 }

--- a/src/main/java/org/example/weneedbe/global/s3/exception/InvalidFileException.java
+++ b/src/main/java/org/example/weneedbe/global/s3/exception/InvalidFileException.java
@@ -1,0 +1,2 @@
+package org.example.weneedbe.global.s3.exception;public class InvalidFileException {
+}


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
모집하려는 유저의 지원서 폼에 해당하는 지원하려는 유저의 지원서작성 API 를 구현하였습니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="1103" alt="스크린샷 2024-03-01 오전 4 28 28" src="https://github.com/Leets-Official/WeNeed-BE/assets/108799865/eda1aef8-2174-4954-9f78-c8937989e814">

<br>

## 4. 완료 사항

- [x] Application domain을 작성하여 기본키와 외래키를 설정
- [x] 지원 지원서(지원하려는 자의 지원서 작성)의 작성 API 를 구현
- [x] 해당 서비스를 구현하면서 발생할수 있는 예외를 처리

<br>

## 5. 추가 사항

- appeal하는 파일이 하나의 파일인지, 여러개의 파일인지에 대한 팀원들과의 상의 후 수정할 예정입니다.
- 현재로는 하나의 파일 + .pdf만 가능하도록 구현하였습니다.

close #93 
